### PR TITLE
feat: Add support for jsx precompile transform setting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -911,6 +911,8 @@ impl ConfigFile {
         }
         return Ok(None);
       }
+      Some("precompile") => "jsx-runtime".to_string(),
+      Some("precompile-dev") => "jsx-dev-runtime".to_string(),
       Some(setting) => bail!(
         "Unsupported 'jsx' compiler option value '{}'. Supported: 'react-jsx', 'react-jsxdev', 'react'\n  at {}",
         setting,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -914,7 +914,7 @@ impl ConfigFile {
       Some("precompile") => "jsx-runtime".to_string(),
       Some("precompile-dev") => "jsx-dev-runtime".to_string(),
       Some(setting) => bail!(
-        "Unsupported 'jsx' compiler option value '{}'. Supported: 'react-jsx', 'react-jsxdev', 'react'\n  at {}",
+        "Unsupported 'jsx' compiler option value '{}'. Supported: 'react-jsx', 'react-jsxdev', 'react', 'precompile', 'precompile-jsx'\n  at {}",
         setting,
         self.specifier,
       ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,9 +912,8 @@ impl ConfigFile {
         return Ok(None);
       }
       Some("precompile") => "jsx-runtime".to_string(),
-      Some("precompile-dev") => "jsx-dev-runtime".to_string(),
       Some(setting) => bail!(
-        "Unsupported 'jsx' compiler option value '{}'. Supported: 'react-jsx', 'react-jsxdev', 'react', 'precompile', 'precompile-jsx'\n  at {}",
+        "Unsupported 'jsx' compiler option value '{}'. Supported: 'react-jsx', 'react-jsxdev', 'react', 'precompile'\n  at {}",
         setting,
         self.specifier,
       ),
@@ -1438,7 +1437,7 @@ mod tests {
     assert_eq!(
       config.to_maybe_jsx_import_source_config().err().unwrap().to_string(),
       concat!(
-        "Unsupported 'jsx' compiler option value 'preserve'. Supported: 'react-jsx', 'react-jsxdev', 'react'\n",
+        "Unsupported 'jsx' compiler option value 'preserve'. Supported: 'react-jsx', 'react-jsxdev', 'react', 'precompile'\n",
         "  at file:///deno/tsconfig.json",
       ),
     );


### PR DESCRIPTION
This PR adds `precompile` as a valid value for the `jsx` setting in `deno.json`.