### PR TITLE
fix: error on 'null' key in exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,7 +759,9 @@ impl ConfigFile {
         validate_value(".", value)?;
         IndexMap::from([(".".to_string(), value.clone())])
       }
-      Some(Value::Bool(_) | Value::Array(_) | Value::Number(_) | Value::Null) => {
+      Some(
+        Value::Bool(_) | Value::Array(_) | Value::Number(_) | Value::Null,
+      ) => {
         bail!("Expected a string or object in exports config.");
       }
       None => IndexMap::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,10 +759,10 @@ impl ConfigFile {
         validate_value(".", value)?;
         IndexMap::from([(".".to_string(), value.clone())])
       }
-      Some(Value::Bool(_)) | Some(Value::Array(_)) | Some(Value::Number(_)) => {
+      Some(Value::Bool(_) | Value::Array(_) | Value::Number(_) | Value::Null) => {
         bail!("Expected a string or object in exports config.");
       }
-      Some(Value::Null) | None => IndexMap::new(),
+      None => IndexMap::new(),
     };
 
     Ok(ExportsConfig {
@@ -1812,6 +1812,11 @@ mod tests {
     run_test(
       r#"{ "exports": [] }"#,
       "Expected a string or object in exports config.",
+    );
+    // null
+    run_test(
+      r#"{ "exports": { "./mod": null }  }"#,
+      "Expected a string in exports config key './mod'.",
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -747,11 +747,9 @@ impl ConfigFile {
             Value::Bool(_)
             | Value::Number(_)
             | Value::Object(_)
-            | Value::Array(_) => {
+            | Value::Array(_)
+            | Value::Null => {
               bail!("Expected a string in exports config key '{}'.", k);
-            }
-            Value::Null => {
-              // ignore
             }
           }
         }


### PR DESCRIPTION
serde deserializes `null` for `Option<serde_json::Value>` as `None` instead of `Some(serde_json::Value::Null)` (which can't kind makes sense I think), so I just can't add a test for `"exports": null`