### PR TITLE
feat: improve improve/exclude

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use std::borrow::Cow;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -9,6 +10,24 @@ use url::Url;
 
 use crate::util::normalize_path;
 use crate::util::specifier_to_file_path;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum FilePatternsMatch {
+  /// File passes as matching, but further exclude matching (ex. .gitignore)
+  /// may be necessary.
+  Passed,
+  /// File passes matching and further exclude matching (ex. .gitignore)
+  /// should NOT be done.
+  PassedOptedOutExclude,
+  /// File was excluded.
+  Excluded,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PathKind {
+  File,
+  Directory,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FilePatterns {
@@ -28,7 +47,11 @@ impl FilePatterns {
     }
   }
 
-  pub fn matches_specifier(&self, specifier: &Url) -> bool {
+  pub fn matches_specifier(
+    &self,
+    specifier: &Url,
+    path_kind: PathKind,
+  ) -> bool {
     if specifier.scheme() != "file" {
       return true;
     }
@@ -36,21 +59,69 @@ impl FilePatterns {
       Ok(path) => path,
       Err(_) => return true,
     };
-    self.matches_path(&path)
+    self.matches_path(&path, path_kind)
   }
 
-  pub fn matches_path(&self, path: &Path) -> bool {
-    // Skip files in the exclude list.
-    if self.exclude.matches_path(path) {
-      return false;
+  pub fn matches_specifier_detail(
+    &self,
+    specifier: &Url,
+    path_kind: PathKind,
+  ) -> FilePatternsMatch {
+    if specifier.scheme() != "file" {
+      // can't do .gitignore on a non-file specifier
+      return FilePatternsMatch::PassedOptedOutExclude;
+    }
+    let path = match specifier_to_file_path(specifier) {
+      Ok(path) => path,
+      Err(_) => return FilePatternsMatch::PassedOptedOutExclude,
+    };
+    self.matches_path_detail(&path, path_kind)
+  }
+
+  pub fn matches_path(&self, path: &Path, path_kind: PathKind) -> bool {
+    self.matches_path_detail(path, path_kind) != FilePatternsMatch::Excluded
+  }
+
+  pub fn matches_path_detail(
+    &self,
+    path: &Path,
+    path_kind: PathKind,
+  ) -> FilePatternsMatch {
+    // if there's an include list, only include files that match it
+    // the include list is a closed set
+    if let Some(include) = &self.include {
+      match path_kind {
+        PathKind::File => {
+          if include.matches_path_detail(path) != PathOrPatternsMatch::Matched {
+            return FilePatternsMatch::Excluded;
+          }
+        }
+        PathKind::Directory => {
+          // for now ignore the include list unless there's a negated
+          // glob for the directory
+          for p in include.0.iter().rev() {
+            match p.matches_path(path) {
+              PathGlobMatch::Matched => {
+                break;
+              }
+              PathGlobMatch::MatchedNegated => {
+                return FilePatternsMatch::Excluded
+              }
+              PathGlobMatch::NotMatched => {
+                // keep going
+              }
+            }
+          }
+        }
+      }
     }
 
-    // Ignore files not in the include list if it's present.
-    self
-      .include
-      .as_ref()
-      .map(|m| m.matches_path(path))
-      .unwrap_or(true)
+    // the exclude list is an open set and we skip files not in the exclude list
+    match self.exclude.matches_path_detail(path) {
+      PathOrPatternsMatch::Matched => FilePatternsMatch::Excluded,
+      PathOrPatternsMatch::NotMatched => FilePatternsMatch::Passed,
+      PathOrPatternsMatch::Excluded => FilePatternsMatch::PassedOptedOutExclude,
+    }
   }
 
   /// Creates a collection of `FilePatterns` where the containing patterns
@@ -164,6 +235,13 @@ impl FilePatterns {
   }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PathOrPatternsMatch {
+  Matched,
+  NotMatched,
+  Excluded,
+}
+
 #[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct PathOrPatternSet(Vec<PathOrPattern>);
 
@@ -202,7 +280,20 @@ impl PathOrPatternSet {
   }
 
   pub fn matches_path(&self, path: &Path) -> bool {
-    self.0.iter().any(|p| p.matches_path(path))
+    self.matches_path_detail(path) == PathOrPatternsMatch::Matched
+  }
+
+  pub fn matches_path_detail(&self, path: &Path) -> PathOrPatternsMatch {
+    for p in self.0.iter().rev() {
+      match p.matches_path(path) {
+        PathGlobMatch::Matched => return PathOrPatternsMatch::Matched,
+        PathGlobMatch::MatchedNegated => return PathOrPatternsMatch::Excluded,
+        PathGlobMatch::NotMatched => {
+          // ignore
+        }
+      }
+    }
+    PathOrPatternsMatch::NotMatched
   }
 
   pub fn base_paths(&self) -> Vec<PathBuf> {
@@ -261,14 +352,22 @@ impl PathOrPattern {
     p: &str,
   ) -> Result<PathOrPattern, anyhow::Error> {
     if is_glob_pattern(p) {
+      let (is_negated, p) = match p.strip_prefix('!') {
+        Some(p) => (true, p),
+        None => (false, p),
+      };
       let p = p.strip_prefix("./").unwrap_or(p);
-      let mut pattern = base.to_string_lossy().replace('\\', "/");
+      let mut pattern = String::new();
+      if is_negated {
+        pattern.push('!');
+      }
+      pattern.push_str(&base.to_string_lossy().replace('\\', "/"));
       if !pattern.ends_with('/') {
         pattern.push('/');
       }
       let p = p.strip_suffix('/').unwrap_or(p);
       pattern.push_str(p);
-      PathOrPattern::new(&pattern)
+      GlobPattern::new(&pattern).map(PathOrPattern::Pattern)
     } else if p.starts_with("http://")
       || p.starts_with("https://")
       || p.starts_with("file://")
@@ -279,10 +378,16 @@ impl PathOrPattern {
     }
   }
 
-  pub fn matches_path(&self, path: &Path) -> bool {
+  pub fn matches_path(&self, path: &Path) -> PathGlobMatch {
     match self {
-      PathOrPattern::Path(p) => path.starts_with(p),
-      PathOrPattern::RemoteUrl(_) => false,
+      PathOrPattern::Path(p) => {
+        if path.starts_with(p) {
+          PathGlobMatch::Matched
+        } else {
+          PathGlobMatch::NotMatched
+        }
+      }
+      PathOrPattern::RemoteUrl(_) => PathGlobMatch::NotMatched,
       PathOrPattern::Pattern(p) => p.matches_path(path),
     }
   }
@@ -306,8 +411,18 @@ impl PathOrPattern {
   }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathGlobMatch {
+  Matched,
+  MatchedNegated,
+  NotMatched,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct GlobPattern(glob::Pattern);
+pub struct GlobPattern {
+  is_negated: bool,
+  pattern: glob::Pattern,
+}
 
 impl GlobPattern {
   pub fn new_if_pattern(pattern: &str) -> Result<Option<Self>, anyhow::Error> {
@@ -318,23 +433,42 @@ impl GlobPattern {
   }
 
   pub fn new(pattern: &str) -> Result<Self, anyhow::Error> {
+    let (is_negated, pattern) = match pattern.strip_prefix('!') {
+      Some(pattern) => (true, pattern),
+      None => (false, pattern),
+    };
     let pattern = escape_brackets(pattern).replace('\\', "/");
     let pattern = glob::Pattern::new(&pattern)
       .with_context(|| format!("Failed to expand glob: \"{}\"", pattern))?;
-    Ok(Self(pattern))
+    Ok(Self {
+      is_negated,
+      pattern,
+    })
   }
 
-  pub fn as_str(&self) -> &str {
-    self.0.as_str()
+  pub fn as_str(&self) -> Cow<str> {
+    if self.is_negated {
+      Cow::Owned(format!("!{}", self.pattern.as_str()))
+    } else {
+      Cow::Borrowed(self.pattern.as_str())
+    }
   }
 
-  pub fn matches_path(&self, path: &Path) -> bool {
-    self.0.matches_path_with(path, match_options())
+  pub fn matches_path(&self, path: &Path) -> PathGlobMatch {
+    if self.pattern.matches_path_with(path, match_options()) {
+      if self.is_negated {
+        PathGlobMatch::MatchedNegated
+      } else {
+        PathGlobMatch::Matched
+      }
+    } else {
+      PathGlobMatch::NotMatched
+    }
   }
 
   pub fn base_path(&self) -> PathBuf {
     let base_path = self
-      .0
+      .pattern
       .as_str()
       .split('/')
       .take_while(|c| !has_glob_chars(c))
@@ -344,7 +478,7 @@ impl GlobPattern {
   }
 
   pub fn is_negated(&self) -> bool {
-    self.0.as_str().starts_with('!')
+    self.is_negated
   }
 }
 
@@ -352,7 +486,7 @@ pub fn is_glob_pattern(path: &str) -> bool {
   !path.starts_with("http://")
     && !path.starts_with("https://")
     && !path.starts_with("file://")
-    && has_glob_chars(path)
+    && (has_glob_chars(path) || path.starts_with('!'))
 }
 
 fn has_glob_chars(pattern: &str) -> bool {
@@ -412,8 +546,7 @@ mod test {
           PathOrPattern::RemoteUrl(_) => None,
           PathOrPattern::Path(p) => Some(path_to_string(root, p)),
           PathOrPattern::Pattern(p) => Some(
-            p.0
-              .as_str()
+            p.as_str()
               .strip_prefix(&format!(
                 "{}/",
                 root.to_string_lossy().replace('\\', "/")

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -47,11 +47,7 @@ impl FilePatterns {
     }
   }
 
-  pub fn matches_specifier(
-    &self,
-    specifier: &Url,
-    path_kind: PathKind,
-  ) -> bool {
+  pub fn matches_specifier(&self, specifier: &Url) -> bool {
     if specifier.scheme() != "file" {
       return true;
     }
@@ -59,7 +55,7 @@ impl FilePatterns {
       Ok(path) => path,
       Err(_) => return true,
     };
-    self.matches_path(&path, path_kind)
+    self.matches_path(&path, PathKind::File) // use file matching behavior
   }
 
   pub fn matches_specifier_detail(
@@ -688,32 +684,74 @@ mod test {
     // leading dot slash
     {
       let pattern = PathOrPattern::from_relative(&cwd, "./**/*.ts").unwrap();
-      assert_eq!(pattern.matches_path(&cwd.join("foo.ts")), true);
-      assert_eq!(pattern.matches_path(&cwd.join("dir/foo.ts")), true);
-      assert_eq!(pattern.matches_path(&cwd.join("foo.js")), false);
-      assert_eq!(pattern.matches_path(&cwd.join("dir/foo.js")), false);
+      assert_eq!(
+        pattern.matches_path(&cwd.join("foo.ts")),
+        PathGlobMatch::Matched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("dir/foo.ts")),
+        PathGlobMatch::Matched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("foo.js")),
+        PathGlobMatch::NotMatched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("dir/foo.js")),
+        PathGlobMatch::NotMatched
+      );
     }
     // no leading dot slash
     {
       let pattern = PathOrPattern::from_relative(&cwd, "**/*.ts").unwrap();
-      assert_eq!(pattern.matches_path(&cwd.join("foo.ts")), true);
-      assert_eq!(pattern.matches_path(&cwd.join("dir/foo.ts")), true);
-      assert_eq!(pattern.matches_path(&cwd.join("foo.js")), false);
-      assert_eq!(pattern.matches_path(&cwd.join("dir/foo.js")), false);
+      assert_eq!(
+        pattern.matches_path(&cwd.join("foo.ts")),
+        PathGlobMatch::Matched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("dir/foo.ts")),
+        PathGlobMatch::Matched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("foo.js")),
+        PathGlobMatch::NotMatched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("dir/foo.js")),
+        PathGlobMatch::NotMatched
+      );
     }
     // exact file, leading dot slash
     {
       let pattern = PathOrPattern::from_relative(&cwd, "./foo.ts").unwrap();
-      assert_eq!(pattern.matches_path(&cwd.join("foo.ts")), true);
-      assert_eq!(pattern.matches_path(&cwd.join("dir/foo.ts")), false);
-      assert_eq!(pattern.matches_path(&cwd.join("foo.js")), false);
+      assert_eq!(
+        pattern.matches_path(&cwd.join("foo.ts")),
+        PathGlobMatch::Matched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("dir/foo.ts")),
+        PathGlobMatch::NotMatched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("foo.js")),
+        PathGlobMatch::NotMatched
+      );
     }
     // exact file, no leading dot slash
     {
       let pattern = PathOrPattern::from_relative(&cwd, "foo.ts").unwrap();
-      assert_eq!(pattern.matches_path(&cwd.join("foo.ts")), true);
-      assert_eq!(pattern.matches_path(&cwd.join("dir/foo.ts")), false);
-      assert_eq!(pattern.matches_path(&cwd.join("foo.js")), false);
+      assert_eq!(
+        pattern.matches_path(&cwd.join("foo.ts")),
+        PathGlobMatch::Matched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("dir/foo.ts")),
+        PathGlobMatch::NotMatched
+      );
+      assert_eq!(
+        pattern.matches_path(&cwd.join("foo.js")),
+        PathGlobMatch::NotMatched
+      );
     }
     // error for invalid url
     {
@@ -732,11 +770,11 @@ mod test {
       assert_eq!(pattern.base_path().unwrap(), parent_dir.join("sibling"));
       assert_eq!(
         pattern.matches_path(&parent_dir.join("sibling/foo.ts")),
-        true
+        PathGlobMatch::Matched
       );
       assert_eq!(
         pattern.matches_path(&parent_dir.join("./other/foo.js")),
-        false
+        PathGlobMatch::NotMatched
       );
     }
   }

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -119,9 +119,11 @@ impl FilePatterns {
       return vec![self.clone()];
     };
 
-    let mut include_paths = Vec::new();
-    let mut include_patterns = Vec::new();
-    let mut exclude_patterns = Vec::new();
+    let mut include_paths = Vec::with_capacity(include.0.len());
+    let mut include_patterns = Vec::with_capacity(include.0.len());
+    let mut exclude_patterns =
+      Vec::with_capacity(include.0.len() + self.exclude.0.len());
+
     for path_or_pattern in &include.0 {
       match path_or_pattern {
         PathOrPattern::Path(path) => include_paths.push((path.is_file(), path)),


### PR DESCRIPTION
Reality of the situation in Deno:

1. `"exclude"` has higher precedence than `"include"`.
   - A file in `"include"` will not be matched against if it's excluded.
2. `"include"` is a closed set.
   - Files not in the include set are not included.

This change makes it more flexible by having the ability to opt out of excluded files. This can be achieved via negated globs in either "publish.exclude" or "exclude" (or "fmt.exclude", "exclude" for the fmt command).

Specifically for checking if a file is excluded for publishing we first check `"publish.include"` for a match, then:

1. We use the array of the config's "exclude" + "publish.exclude" (done in https://github.com/denoland/deno_config/pull/43)
2. Go through each entry in reverse.
   1. If entry is matched as opted-in (ex. !/dist/), then we consider that as NOT excluded.
   2. If entry is matched for an exclusion (ex. /dist/file.txt), then we consider that as excluded.
   3. We bail on the first positive or negative match for perf reasons.
3. At this point, if the file has not had a positive or negative match, we check if the gitignore excludes the file.

So for example, to include a file that's been gitignored during publishing, the following will be possible:

```
# gitignore
file.txt
```

```json
{
  "publish": {
    "exclude": [
      "!file.txt"
    ]
  }
}
```