### PR TITLE
fix: handle invalid negations

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -329,11 +329,6 @@ impl PathOrPatternSet {
       entry_path: &Path,
     ) -> Result<(), anyhow::Error> {
       for (negated_entry, negated_path) in found_negated_paths {
-        eprintln!(
-          "NEGATED: {}, {}",
-          negated_path.display(),
-          entry_path.display()
-        );
         if negated_path.starts_with(entry_path) {
           bail!(
             concat!(

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -193,8 +193,7 @@ impl FilePatterns {
             PathOrPattern::RemoteUrl(_) => None,
             PathOrPattern::Path(exclude_path)
             | PathOrPattern::NegatedPath(exclude_path) => {
-              // For explicitly specified files, ignore when the exclude path starts
-              // with it. Regardless, include excludes that are on a sub path of the dir.
+              // include paths that's are sub paths or an ancestor path
               if base_path.starts_with(exclude_path)
                 || exclude_path.starts_with(base_path)
               {
@@ -204,7 +203,7 @@ impl FilePatterns {
               }
             }
             PathOrPattern::Pattern(_) => {
-              // include globs that's are sub paths or a parent path
+              // include globs that's are sub paths or an ancestor path
               if exclude_base_path.starts_with(base_path)
                 || base_path.starts_with(exclude_base_path)
               {

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -329,11 +329,16 @@ impl PathOrPatternSet {
       entry_path: &Path,
     ) -> Result<(), anyhow::Error> {
       for (negated_entry, negated_path) in found_negated_paths {
+        eprintln!(
+          "NEGATED: {}, {}",
+          negated_path.display(),
+          entry_path.display()
+        );
         if negated_path.starts_with(entry_path) {
           bail!(
             concat!(
               "Invalid config file exclude. The negation of '{0}' is never ",
-              "reached due to the higher priority '{1}' entry. Move '{0}' after '{1}'.",
+              "reached due to the higher priority '{1}' exclude. Move '{0}' after '{1}'.",
             ),
             negated_entry,
             entry,
@@ -359,9 +364,9 @@ impl PathOrPatternSet {
           // ignore
         }
         PathOrPattern::Pattern(p) => {
-          if !p.is_negated() {
+          if p.is_negated() {
             let base_path = p.base_path();
-            validate_entry(&found_negated_paths, entry, &base_path)?;
+            found_negated_paths.push((entry.as_str(), base_path));
           }
         }
       }

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -303,22 +303,17 @@ impl PathOrPatternSet {
     ))
   }
 
-  /// Builds the set and ensures no negations.
+  /// Builds the set of path and patterns for an "include" list.
   pub fn from_include_relative_path_or_patterns(
     base: &Path,
     entries: &[String],
   ) -> Result<Self, anyhow::Error> {
-    let mut result = Vec::with_capacity(entries.len());
-    for entry in entries {
-      let p = PathOrPattern::from_relative(base, entry)?;
-      // for now, just don't support this until someone wants
-      // it even though it should work well with the current code
-      if p.is_negated() {
-        bail!("Negated entry '{}' not supported in \"include\". Move to \"exclude\" instead.", entry)
-      }
-      result.push(p);
-    }
-    Ok(Self(result))
+    Ok(Self(
+      entries
+        .iter()
+        .map(|p| PathOrPattern::from_relative(base, p))
+        .collect::<Result<Vec<_>, _>>()?,
+    ))
   }
 
   /// Builds the set and ensures no negations are overruled by

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -332,8 +332,8 @@ impl PathOrPatternSet {
         if negated_path.starts_with(entry_path) {
           bail!(
             concat!(
-              "Invalid config file exclude. The negation of '{0}' is never ",
-              "reached due to the higher priority '{1}' exclude. Move '{0}' after '{1}'.",
+              "The negation of '{0}' is never reached due to the higher ",
+              "priority '{1}' exclude. Move '{0}' after '{1}'.",
             ),
             negated_entry,
             entry,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1728,7 +1728,7 @@ mod tests {
   }
 
   #[test]
-  fn test_parse_config_exclude_lower_priority() {
+  fn test_parse_config_exclude_lower_priority_path() {
     let config_text = r#"{
       "fmt": {
         "exclude": ["!dist/data", "dist/"]
@@ -1743,7 +1743,27 @@ mod tests {
       r#"Invalid config file exclude.
 
 Caused by:
-    Invalid config file exclude. The negation of '!dist/data' is never reached due to the higher priority 'dist/' entry. Move '!dist/data' after 'dist/'."#
+    Invalid config file exclude. The negation of '!dist/data' is never reached due to the higher priority 'dist/' exclude. Move '!dist/data' after 'dist/'."#
+    );
+  }
+
+  #[test]
+  fn test_parse_config_exclude_lower_priority_glob() {
+    let config_text = r#"{
+      "fmt": {
+        "exclude": ["!dist/data/**/*.ts", "dist/"]
+      }
+    }"#;
+    let config_specifier = Url::parse("file:///deno/tsconfig.json").unwrap();
+    let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
+
+    let err = config_file.to_fmt_config().err().unwrap();
+    assert_eq!(
+      format!("{:?}", err),
+      r#"Invalid config file exclude.
+
+Caused by:
+    Invalid config file exclude. The negation of '!dist/data/**/*.ts' is never reached due to the higher priority 'dist/' exclude. Move '!dist/data/**/*.ts' after 'dist/'."#
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl SerializedFilesConfig {
             &config_dir,
             &i,
           )
-          .context("Invalid config file include.")?,
+          .context("Invalid include.")?,
         ),
         None => None,
       },
@@ -82,7 +82,7 @@ impl SerializedFilesConfig {
         &config_dir,
         &self.exclude,
       )
-      .context("Invalid config file exclude.")?,
+      .context("Invalid exclude.")?,
     })
   }
 
@@ -950,7 +950,9 @@ impl ConfigFile {
       exclude,
       ..Default::default()
     };
-    raw_files_config.into_resolved(&self.specifier)
+    raw_files_config
+      .into_resolved(&self.specifier)
+      .context("Invalid exclude config.")
   }
 
   fn resolve_exclude_patterns(&self) -> Result<Vec<String>, AnyError> {
@@ -983,7 +985,10 @@ impl ConfigFile {
       None => return Ok(None),
     };
 
-    serialized.into_resolved(&self.specifier).map(Some)
+    serialized
+      .into_resolved(&self.specifier)
+      .context("Invalid bench config.")
+      .map(Some)
   }
 
   pub fn to_fmt_config(&self) -> Result<Option<FmtConfig>, AnyError> {
@@ -1005,7 +1010,10 @@ impl ConfigFile {
       None => return Ok(None),
     };
 
-    serialized.into_resolved(&self.specifier).map(Some)
+    serialized
+      .into_resolved(&self.specifier)
+      .context("Invalid fmt config.")
+      .map(Some)
   }
 
   pub fn to_lint_config(&self) -> Result<Option<LintConfig>, AnyError> {
@@ -1027,7 +1035,10 @@ impl ConfigFile {
       None => return Ok(None),
     };
 
-    serialized.into_resolved(&self.specifier).map(Some)
+    serialized
+      .into_resolved(&self.specifier)
+      .context("Invalid lint config.")
+      .map(Some)
   }
 
   pub fn to_test_config(&self) -> Result<Option<TestConfig>, AnyError> {
@@ -1049,7 +1060,10 @@ impl ConfigFile {
       None => return Ok(None),
     };
 
-    serialized.into_resolved(&self.specifier).map(Some)
+    serialized
+      .into_resolved(&self.specifier)
+      .context("Invalid test config.")
+      .map(Some)
   }
 
   pub fn to_publish_config(&self) -> Result<Option<PublishConfig>, AnyError> {
@@ -1071,7 +1085,10 @@ impl ConfigFile {
       None => return Ok(None),
     };
 
-    serialized.into_resolved(&self.specifier).map(Some)
+    serialized
+      .into_resolved(&self.specifier)
+      .context("Invalid publish config.")
+      .map(Some)
   }
 
   pub fn to_workspace_config(
@@ -1740,30 +1757,32 @@ mod tests {
     let err = config_file.to_fmt_config().err().unwrap();
     assert_eq!(
       format!("{:?}", err),
-      r#"Invalid config file exclude.
+      r#"Invalid fmt config.
 
 Caused by:
-    Invalid config file exclude. The negation of '!dist/data' is never reached due to the higher priority 'dist/' exclude. Move '!dist/data' after 'dist/'."#
+    0: Invalid exclude.
+    1: The negation of '!dist/data' is never reached due to the higher priority 'dist/' exclude. Move '!dist/data' after 'dist/'."#
     );
   }
 
   #[test]
   fn test_parse_config_exclude_lower_priority_glob() {
     let config_text = r#"{
-      "fmt": {
+      "lint": {
         "exclude": ["!dist/data/**/*.ts", "dist/"]
       }
     }"#;
     let config_specifier = Url::parse("file:///deno/tsconfig.json").unwrap();
     let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
 
-    let err = config_file.to_fmt_config().err().unwrap();
+    let err = config_file.to_lint_config().err().unwrap();
     assert_eq!(
       format!("{:?}", err),
-      r#"Invalid config file exclude.
+      r#"Invalid lint config.
 
 Caused by:
-    Invalid config file exclude. The negation of '!dist/data/**/*.ts' is never reached due to the higher priority 'dist/' exclude. Move '!dist/data/**/*.ts' after 'dist/'."#
+    0: Invalid exclude.
+    1: The negation of '!dist/data/**/*.ts' is never reached due to the higher priority 'dist/' exclude. Move '!dist/data/**/*.ts' after 'dist/'."#
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1728,26 +1728,6 @@ mod tests {
   }
 
   #[test]
-  fn test_parse_config_include_negations() {
-    let config_text = r#"{
-      "fmt": {
-        "include": ["src/", "!src/testdata/"]
-      }
-    }"#;
-    let config_specifier = Url::parse("file:///deno/tsconfig.json").unwrap();
-    let config_file = ConfigFile::new(config_text, config_specifier).unwrap();
-
-    let err = config_file.to_fmt_config().err().unwrap();
-    assert_eq!(
-      format!("{:?}", err),
-      r#"Invalid config file include.
-
-Caused by:
-    Negated entry '!src/testdata/' not supported in "include". Move to "exclude" instead."#
-    );
-  }
-
-  #[test]
   fn test_parse_config_exclude_lower_priority() {
     let config_text = r#"{
       "fmt": {


### PR DESCRIPTION
Errors when someone does:

```
{
  "exclude": [
    "!dist/sub_dir/".
    "dist/"
  ]
}
```

and tells them to swap the entries.