### PR TITLE
feat: Collect comments attached to task definitions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -710,13 +710,13 @@ impl ConfigFile {
     ) {
       Ok(ParseResult {
         comments: Some(comments),
-        value: Some(value),
+        value: Some(jsonc_parser::ast::Value::Object(value)),
         tokens: Some(tokens),
         ..
-      }) if value.as_object().is_some() => {
-        let value_obj = value.as_object().unwrap();
-        let mut value_json = Value::from(value.clone());
-        if let Some(tasks) = value_obj.get_object("tasks") {
+      }) => {
+        let mut value_json =
+          Value::from(jsonc_parser::ast::Value::Object(value.clone()));
+        if let Some(tasks) = value.get_object("tasks") {
           let decorated_tasks =
             decorate_tasks_json(text, &tokens, &comments, tasks);
           value_json["tasks"] = decorated_tasks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,7 +485,7 @@ pub struct ConfigFile {
 /// returns a new object where each task
 /// has a list of the comments that accompanied it.
 /// i.e. it will be the following form
-/// 
+///
 /// ```json
 /// {
 ///   "tasks": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,9 +547,9 @@ fn decorate_tasks_json(
 
       let comment_lines = comment
         .text()
+        .trim()
         .split('\n')
-        .map(|s| s.trim().trim_start_matches('*').trim_start().to_string())
-        .filter(|s| !s.is_empty());
+        .map(|s| s.trim().trim_start_matches('*').trim_start().to_string());
       comment_texts.extend(comment_lines);
     }
 
@@ -2806,6 +2806,7 @@ Caused by:
         "run": "deno run -A mod.ts", // comments not supported here
         /*
          * test task
+         * 
          * with multi-line comments
          */
         "test": "deno test",
@@ -2847,6 +2848,7 @@ Caused by:
             definition: "deno test".into(),
             comments: vec![
               "test task".into(),
+              "".into(),
               "with multi-line comments".into()
             ]
           }


### PR DESCRIPTION
Preserve comments that are in a task definition and expose them as part of the tasks config.

The code is still kinda gnarly, but here for review