### PR TITLE
feat: EmitConfigOptions - add `remove_comments`

### DIFF
--- a/src/ts.rs
+++ b/src/ts.rs
@@ -48,6 +48,7 @@ pub struct EmitConfigOptions {
   pub imports_not_used_as_values: String,
   pub inline_source_map: bool,
   pub inline_sources: bool,
+  pub remove_comments: bool,
   pub source_map: bool,
   pub jsx: String,
   pub jsx_factory: String,


### PR DESCRIPTION
For the opt-in ability to remove comments from the transpiled output.