### PR TITLE
fix: derive `Hash` on more structs

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -30,7 +30,7 @@ pub enum PathKind {
   Directory,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct FilePatterns {
   /// Default traversal base used when calling `split_by_base()` without
   /// any `include` patterns.
@@ -278,14 +278,14 @@ impl FilePatterns {
   }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum PathOrPatternsMatch {
   Matched,
   NotMatched,
   Excluded,
 }
 
-#[derive(Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Default, Debug, Hash, Eq, PartialEq)]
 pub struct PathOrPatternSet(Vec<PathOrPattern>);
 
 impl PathOrPatternSet {
@@ -414,7 +414,7 @@ impl PathOrPatternSet {
   }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum PathOrPattern {
   Path(PathBuf),
   NegatedPath(PathBuf),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub enum ConfigFlag {
   Disabled,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Hash, PartialEq)]
 #[serde(default, deny_unknown_fields)]
 pub struct LintRulesConfig {
   pub tags: Option<Vec<String>>,
@@ -174,14 +174,14 @@ impl SerializedLintConfig {
   }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq)]
 pub struct LintConfig {
   pub rules: LintRulesConfig,
   pub files: FilePatterns,
   pub report: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Hash, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub enum ProseWrap {
   Always,
@@ -189,7 +189,7 @@ pub enum ProseWrap {
   Preserve,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Hash, PartialEq)]
 #[serde(default, deny_unknown_fields, rename_all = "camelCase")]
 pub struct FmtOptionsConfig {
   pub use_tabs: Option<bool>,
@@ -295,7 +295,7 @@ impl SerializedFmtConfig {
   }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq)]
 pub struct FmtConfig {
   pub options: FmtOptionsConfig,
   pub files: FilePatterns,
@@ -354,7 +354,7 @@ impl SerializedTestConfig {
   }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq)]
 pub struct TestConfig {
   pub files: FilePatterns,
 }
@@ -383,7 +383,7 @@ impl SerializedPublishConfig {
   }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq)]
 pub struct PublishConfig {
   pub files: FilePatterns,
 }


### PR DESCRIPTION
In the CLI, some code is doing `serde_json::to_string` to get a hash of this config. We can just make these derive `Hash` instead.