### PR TITLE
fix: only consider name and exports for if is a package

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -939,9 +939,7 @@ impl ConfigFile {
   }
 
   pub fn is_package(&self) -> bool {
-    self.json.name.is_some()
-      && self.json.version.is_some()
-      && self.json.exports.is_some()
+    self.json.name.is_some() && self.json.exports.is_some()
   }
 
   pub fn has_unstable(&self, name: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2769,7 +2769,7 @@ Caused by:
         "version": "1.0.0"
       }"#
     ));
-    assert!(!get_for_config(
+    assert!(get_for_config(
       r#"{
         "name": "test",
         "exports": "./mod.ts"


### PR DESCRIPTION
Reason: The upcoming `deno publish --version 0.1.0` or whatever flag might cause some deno.json files to not have a version in them.