### PR TITLE
feat: remove requirement to specify current file in members when workspace root config is package

### DIFF
--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -177,8 +177,7 @@ pub fn discover_workspace_config_files(
               .into(),
             )
           })?;
-        if member_dir_url == root_config_file_directory_url && raw_member != "."
-        {
+        if member_dir_url == root_config_file_directory_url {
           return Err(
             ResolveWorkspaceMemberError::InvalidSelfReference {
               member: raw_member.to_string(),


### PR DESCRIPTION
Aligns with cargo.

Changes it to not require `"."` in the workspace root and not surface diagnostics about it because we can tell if the root is a package by if it has name and exports fields.

Changes:

```json
{
  "name": "@scope/root",
  "version": "1.0.0",
  "exports": "./mod.ts"
  "workspace": [".", "./sub_package"]
}
```

To:

```json
{
  "name": "@scope/root",
  "version": "1.0.0",
  "exports": "./mod.ts",
  "workspace": ["./sub_package"]
}
```