### PR TITLE
feat: restore resolving config from multiple paths and combine config discovery

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -7,13 +7,21 @@ use std::path::PathBuf;
 use thiserror::Error;
 use url::Url;
 
-#[derive(Default)]
-pub struct CheckedSet<T: std::hash::Hash> {
+pub struct CheckedSet<T: std::hash::Hash + ?Sized> {
   _kind: PhantomData<T>,
   checked: std::collections::HashSet<u64>,
 }
 
-impl<T: std::hash::Hash> CheckedSet<T> {
+impl<T: std::hash::Hash + ?Sized> Default for CheckedSet<T> {
+  fn default() -> Self {
+    Self {
+      _kind: Default::default(),
+      checked: Default::default(),
+    }
+  }
+}
+
+impl<T: std::hash::Hash + ?Sized> CheckedSet<T> {
   pub fn with_capacity(capacity: usize) -> Self {
     Self {
       _kind: PhantomData,

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::Path;
-use std::path::PathBuf;
 
 use url::Url;
 
@@ -14,7 +13,9 @@ use crate::package_json::PackageJsonRc;
 use crate::sync::new_rc;
 use crate::util::is_skippable_io_error;
 use crate::util::normalize_path;
+use crate::util::specifier_parent;
 use crate::util::specifier_to_file_path;
+use crate::util::CheckedSet;
 use crate::ConfigFile;
 use crate::ConfigFileRc;
 
@@ -31,348 +32,409 @@ pub enum DenoOrPkgJson {
   PkgJson(crate::package_json::PackageJsonRc),
 }
 
+impl DenoOrPkgJson {
+  pub fn specifier(&self) -> Cow<Url> {
+    match self {
+      Self::Deno(config) => Cow::Borrowed(&config.specifier),
+      Self::PkgJson(pkg_json) => Cow::Owned(pkg_json.specifier()),
+    }
+  }
+}
+
+#[derive(Debug)]
+pub enum ConfigFolder {
+  Single(DenoOrPkgJson),
+  Both {
+    deno_json: ConfigFileRc,
+    pkg_json: PackageJsonRc,
+  },
+}
+
+impl ConfigFolder {
+  pub fn folder_url(&self) -> Url {
+    match self {
+      Self::Single(DenoOrPkgJson::Deno(config)) => {
+        specifier_parent(&config.specifier)
+      }
+      Self::Single(DenoOrPkgJson::PkgJson(pkg_json)) => {
+        Url::from_directory_path(pkg_json.path.parent().unwrap()).unwrap()
+      }
+      Self::Both { deno_json, .. } => specifier_parent(&deno_json.specifier),
+    }
+  }
+
+  pub fn is_workspace(&self) -> bool {
+    match self {
+      Self::Single(DenoOrPkgJson::Deno(config)) => {
+        config.json.workspace.is_some()
+      }
+      Self::Single(DenoOrPkgJson::PkgJson(pkg_json)) => {
+        pkg_json.workspaces.is_some()
+      }
+      Self::Both {
+        deno_json,
+        pkg_json,
+      } => deno_json.json.workspace.is_some() || pkg_json.workspaces.is_some(),
+    }
+  }
+
+  pub fn deno_json(&self) -> Option<&ConfigFileRc> {
+    match self {
+      Self::Single(DenoOrPkgJson::Deno(deno_json)) => Some(deno_json),
+      Self::Both { deno_json, .. } => Some(deno_json),
+      _ => None,
+    }
+  }
+
+  pub fn pkg_json(&self) -> Option<&PackageJsonRc> {
+    match self {
+      Self::Single(DenoOrPkgJson::PkgJson(pkg_json)) => Some(pkg_json),
+      Self::Both { pkg_json, .. } => Some(pkg_json),
+      _ => None,
+    }
+  }
+
+  pub fn from_maybe_both(
+    maybe_deno_json: Option<ConfigFileRc>,
+    maybe_pkg_json: Option<PackageJsonRc>,
+  ) -> Option<Self> {
+    match (maybe_deno_json, maybe_pkg_json) {
+      (Some(deno_json), Some(pkg_json)) => Some(Self::Both {
+        deno_json,
+        pkg_json,
+      }),
+      (Some(deno_json), None) => {
+        Some(Self::Single(DenoOrPkgJson::Deno(deno_json)))
+      }
+      (None, Some(pkg_json)) => {
+        Some(Self::Single(DenoOrPkgJson::PkgJson(pkg_json)))
+      }
+      (None, None) => None,
+    }
+  }
+}
+
 #[derive(Debug)]
 pub enum ConfigFileDiscovery {
   None,
-  Single(ConfigFileRc),
+  Single(ConfigFolder),
   Workspace {
-    root: ConfigFileRc,
-    members: BTreeMap<UrlRc, DenoOrPkgJson>,
+    root: ConfigFolder,
+    members: BTreeMap<UrlRc, ConfigFolder>,
   },
+}
+
+impl ConfigFileDiscovery {
+  fn root_config_specifier(&self) -> Option<Cow<Url>> {
+    match self {
+      Self::None => None,
+      Self::Single(res) => Some(config_folder_config_specifier(res)),
+      Self::Workspace { root, .. } => {
+        Some(config_folder_config_specifier(root))
+      }
+    }
+  }
+}
+
+fn config_folder_config_specifier(res: &ConfigFolder) -> Cow<Url> {
+  match res {
+    ConfigFolder::Single(config) => config.specifier(),
+    ConfigFolder::Both { deno_json, .. } => Cow::Borrowed(&deno_json.specifier),
+  }
 }
 
 pub fn discover_workspace_config_files(
   start: WorkspaceDiscoverStart,
   opts: &WorkspaceDiscoverOptions,
 ) -> Result<ConfigFileDiscovery, WorkspaceDiscoverError> {
-  let mut next_start_dir: Option<Cow<Path>>;
-  let mut first_config_file: Option<Url> = None;
-  let mut found_configs: HashMap<_, ConfigFile> = HashMap::new();
   match start {
-    WorkspaceDiscoverStart::Dir(dir) => {
-      next_start_dir = Some(Cow::Borrowed(dir));
-    }
+    WorkspaceDiscoverStart::Dirs(dirs) => match dirs.len() {
+      0 => Ok(ConfigFileDiscovery::None),
+      1 => {
+        let dir = &dirs[0];
+        let start = DirOrConfigFile::Dir(dir);
+        discover_workspace_config_files_for_single_dir(start, opts, None)
+      }
+      _ => {
+        let mut checked = CheckedSet::default();
+        let mut discovered_workspace = ConfigFileDiscovery::None;
+        for dir in dirs {
+          let workspace = discover_workspace_config_files_for_single_dir(
+            DirOrConfigFile::Dir(dir),
+            opts,
+            Some(&mut checked),
+          )?;
+          if let Some(root_config_specifier) = workspace.root_config_specifier()
+          {
+            if let Some(discovered_root_config_specifier) =
+              discovered_workspace.root_config_specifier()
+            {
+              return Err(WorkspaceDiscoverError(
+                WorkspaceDiscoverErrorKind::MultipleWorkspaces {
+                  base_workspace_url: root_config_specifier.into_owned(),
+                  other_workspace_url: discovered_root_config_specifier
+                    .into_owned(),
+                }
+                .into(),
+              ));
+            }
+            discovered_workspace = workspace;
+          }
+        }
+        Ok(discovered_workspace)
+      }
+    },
     WorkspaceDiscoverStart::ConfigFile(file) => {
-      next_start_dir =
-        file.parent().and_then(|p| p.parent()).map(Cow::Borrowed);
+      let start = DirOrConfigFile::ConfigFile(file);
+      discover_workspace_config_files_for_single_dir(start, opts, None)
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DirOrConfigFile<'a> {
+  Dir(&'a Path),
+  ConfigFile(&'a Path),
+}
+
+fn discover_workspace_config_files_for_single_dir(
+  start: DirOrConfigFile,
+  opts: &WorkspaceDiscoverOptions,
+  mut checked: Option<&mut CheckedSet<Path>>,
+) -> Result<ConfigFileDiscovery, WorkspaceDiscoverError> {
+  let start_dir: &Path;
+  let mut first_config_folder_url: Option<Url> = None;
+  let mut found_config_folders: HashMap<_, ConfigFolder> = HashMap::new();
+  let config_file_names =
+    ConfigFile::resolve_config_file_names(opts.additional_config_file_names);
+  let load_pkg_json_in_folder = |folder_path: &Path| {
+    if opts.discover_pkg_json {
+      let pkg_json_path = folder_path.join("package.json");
+      match PackageJson::load_from_path(
+        &pkg_json_path,
+        opts.fs,
+        opts.pkg_json_cache,
+      ) {
+        Ok(pkg_json) => Ok(Some(pkg_json)),
+        Err(PackageJsonLoadError::Io { source, .. })
+          if is_skippable_io_error(&source) =>
+        {
+          Ok(None)
+        }
+        Err(err) => Err(err),
+      }
+    } else {
+      Ok(None)
+    }
+  };
+  let load_config_folder =
+    |folder_path: &Path| -> Result<_, ResolveWorkspaceMemberError> {
+      let maybe_config_file = ConfigFile::maybe_find_in_folder(
+        opts.fs,
+        folder_path,
+        &config_file_names,
+        &opts.config_parse_options,
+      )?;
+      let maybe_pkg_json = load_pkg_json_in_folder(folder_path)?;
+      Ok(ConfigFolder::from_maybe_both(
+        maybe_config_file.map(new_rc),
+        maybe_pkg_json,
+      ))
+    };
+  match start {
+    DirOrConfigFile::Dir(dir) => {
+      start_dir = dir;
+    }
+    DirOrConfigFile::ConfigFile(file) => {
+      start_dir = file.parent().ok_or_else(|| {
+        WorkspaceDiscoverErrorKind::FailedResolvingStartDirectory(
+          anyhow::anyhow!(
+            "Provided config file path ('{}') had no parent directory.",
+            file.display()
+          ),
+        )
+      })?;
       let specifier = Url::from_file_path(file).unwrap();
-      let config_file = ConfigFile::from_specifier(
+      let config_file = new_rc(ConfigFile::from_specifier(
         opts.fs,
         specifier.clone(),
         &opts.config_parse_options,
-      )?;
-      found_configs.insert(specifier.clone(), config_file);
-      first_config_file = Some(specifier);
+      )?);
+      let maybe_pkg_json = load_pkg_json_in_folder(&config_file.dir_path())?;
+      let parent_dir_url = specifier_parent(&config_file.specifier);
+      found_config_folders.insert(
+        parent_dir_url.clone(),
+        ConfigFolder::from_maybe_both(Some(config_file), maybe_pkg_json)
+          .unwrap(),
+      );
+      first_config_folder_url = Some(parent_dir_url);
     }
   }
-  while let Some(start_dir) = next_start_dir.take() {
-    let config_file = ConfigFile::discover_from(
-      opts.fs,
-      &start_dir,
-      opts.additional_config_file_names,
-      &opts.config_parse_options,
-    )?;
-    let Some(workspace_config_file) = config_file else {
-      break;
-    };
-    let workspace_field = workspace_config_file.json.workspace.as_ref();
-    if let Some(members) = workspace_field {
-      if members.is_empty() {
-        return Err(
-          WorkspaceDiscoverErrorKind::MembersEmpty(
-            workspace_config_file.specifier.clone(),
-          )
-          .into(),
-        );
+  for current_dir in start_dir.ancestors() {
+    if let Some(checked) = checked.as_mut() {
+      if !checked.insert(current_dir) {
+        // already visited here, so exit
+        return Ok(ConfigFileDiscovery::None);
       }
-      let config_file_path =
-        specifier_to_file_path(&workspace_config_file.specifier).unwrap();
-      let root_config_file_directory = config_file_path.parent().unwrap();
-      let root_config_file_directory_url =
-        Url::from_directory_path(root_config_file_directory).unwrap();
-      let mut final_members = BTreeMap::new();
-      for raw_member in members {
-        let mut find_config = |member_dir_url: &Url| {
-          let config_file_names = ConfigFile::resolve_config_file_names(
-            opts.additional_config_file_names,
-          );
-          let config_file_urls = config_file_names
-            .iter()
-            .map(|name| member_dir_url.join(name).unwrap())
-            .collect::<Vec<_>>();
-          // try to find the config in memory from the configs we already
-          // found on the file system
-          if !found_configs.is_empty() {
-            for url in &config_file_urls {
-              if let Some(config_file) = found_configs.remove(url) {
-                return Ok(DenoOrPkgJson::Deno(new_rc(config_file)));
-              }
-            }
-          }
+    }
 
-          // now search the file system
-          for url in config_file_urls {
-            let result = ConfigFile::from_specifier(
-              opts.fs,
-              url,
-              &opts.config_parse_options,
-            );
-            match result {
-              Ok(config_file) => {
-                log::debug!(
-                  "Member config file found at '{}'",
-                  config_file.specifier
-                );
-                return Ok(DenoOrPkgJson::Deno(new_rc(config_file)));
+    let maybe_config_folder = load_config_folder(current_dir)?;
+    let Some(root_config_folder) = maybe_config_folder else {
+      continue;
+    };
+    if root_config_folder.is_workspace() {
+      let mut final_members = BTreeMap::new();
+      let root_config_file_directory_url = root_config_folder.folder_url();
+      let root_config_file_path =
+        specifier_to_file_path(&root_config_file_directory_url).unwrap();
+      let resolve_member_url =
+        |raw_member: &str| -> Result<Url, ResolveWorkspaceMemberError> {
+          let member = if !raw_member.ends_with('/') {
+            Cow::Owned(format!("{}/", raw_member))
+          } else {
+            Cow::Borrowed(raw_member)
+          };
+          let member_dir_url = root_config_file_directory_url
+            .join(&member)
+            .map_err(|err| ResolveWorkspaceMemberError::InvalidMember {
+              base: root_config_folder.folder_url(),
+              member: raw_member.to_owned(),
+              source: err,
+            })?;
+          if member_dir_url == root_config_file_directory_url {
+            return Err(ResolveWorkspaceMemberError::InvalidSelfReference {
+              member: raw_member.to_string(),
+            });
+          }
+          if !member_dir_url
+            .as_str()
+            .starts_with(root_config_file_directory_url.as_str())
+          {
+            return Err(ResolveWorkspaceMemberError::NonDescendant {
+              workspace_url: root_config_file_directory_url.clone(),
+              member_url: member_dir_url,
+            });
+          }
+          Ok(member_dir_url)
+        };
+      let mut add_member = |raw_member: &str,
+                            member_dir_url: Url|
+       -> Result<(), ResolveWorkspaceMemberError> {
+        let mut find_member_config_folder =
+          || -> Result<_, ResolveWorkspaceMemberError> {
+            // try to find the config folder in memory from the configs we already
+            // found on the file system
+            if let Some(config_folder) =
+              found_config_folders.remove(&member_dir_url)
+            {
+              return Ok(config_folder);
+            }
+
+            let maybe_config_folder = load_config_folder(&normalize_path(
+              root_config_file_path.join(raw_member),
+            ))?;
+            maybe_config_folder.ok_or_else(|| {
+              ResolveWorkspaceMemberError::NotFound {
+                dir_url: member_dir_url.clone(),
               }
-              Err(err) if err.is_not_found() => {
-                // keep searching
+            })
+          };
+
+        let member_config_folder = find_member_config_folder()?;
+        let previous_member =
+          final_members.insert(new_rc(member_dir_url), member_config_folder);
+        if previous_member.is_some() {
+          Err(ResolveWorkspaceMemberError::Duplicate {
+            member: raw_member.to_string(),
+          })
+        } else {
+          Ok(())
+        }
+      };
+      if let Some(deno_json) = root_config_folder.deno_json() {
+        if let Some(members) = &deno_json.json.workspace {
+          if members.is_empty() {
+            return Err(
+              WorkspaceDiscoverErrorKind::MembersEmpty(
+                deno_json.specifier.clone(),
+              )
+              .into(),
+            );
+          }
+          for raw_member in members {
+            let member_url = resolve_member_url(raw_member)?;
+            add_member(raw_member, member_url)?;
+          }
+        }
+      }
+      if let Some(pkg_json) = root_config_folder.pkg_json() {
+        if let Some(members) = &pkg_json.workspaces {
+          let mut has_warned = false;
+          for member in members {
+            if member.contains('*') {
+              if !has_warned {
+                has_warned = true;
+                log::warn!(
+                  "Wildcards in npm workspaces are not yet supported. Ignoring."
+                );
+              }
+              continue;
+            }
+
+            let member_dir_url = resolve_member_url(member)?;
+            match add_member(member, member_dir_url) {
+              Ok(()) => {}
+              Err(ResolveWorkspaceMemberError::Duplicate { .. }) => {
+                // ignore for package.json members
               }
               Err(err) => return Err(err.into()),
             }
           }
-
-          // now check for a package.json
-          let package_json_url = member_dir_url.join("package.json").unwrap();
-          let package_json_path =
-            specifier_to_file_path(&package_json_url).unwrap();
-          let pkg_json_result = PackageJson::load_from_path(
-            &package_json_path,
-            opts.fs,
-            opts.pkg_json_cache,
-          );
-          match pkg_json_result {
-            Ok(pkg_json) => {
-              log::debug!(
-                "Member package.json found at '{}'",
-                pkg_json.path.display()
-              );
-              Ok(DenoOrPkgJson::PkgJson(pkg_json))
-            }
-            Err(PackageJsonLoadError::Io { source, .. })
-              if source.kind() == std::io::ErrorKind::NotFound =>
-            {
-              Err(ResolveWorkspaceMemberError::NotFound {
-                dir_url: member_dir_url.clone(),
-              })
-            }
-            Err(err) => Err(err.into()),
-          }
-        };
-
-        let member = if !raw_member.ends_with('/') {
-          Cow::Owned(format!("{}/", raw_member))
-        } else {
-          Cow::Borrowed(raw_member)
-        };
-        let member_dir_url = root_config_file_directory_url
-          .join(&member)
-          .map_err(|err| {
-            WorkspaceDiscoverError(
-              WorkspaceDiscoverErrorKind::InvalidMember {
-                base: workspace_config_file.specifier.clone(),
-                member: raw_member.clone(),
-                source: err,
-              }
-              .into(),
-            )
-          })?;
-        if member_dir_url == root_config_file_directory_url {
-          return Err(
-            ResolveWorkspaceMemberError::InvalidSelfReference {
-              member: raw_member.to_string(),
-            }
-            .into(),
-          );
         }
-        if !member_dir_url
-          .as_str()
-          .starts_with(root_config_file_directory_url.as_str())
-        {
-          return Err(
-            ResolveWorkspaceMemberError::NonDescendant {
-              workspace_url: root_config_file_directory_url.clone(),
-              member_url: member_dir_url,
-            }
-            .into(),
-          );
-        }
-        let config = find_config(&member_dir_url)?;
-        let previous_member =
-          final_members.insert(new_rc(member_dir_url), config);
-        if previous_member.is_some() {
-          return Err(
-            ResolveWorkspaceMemberError::Duplicate {
-              member: raw_member.to_string(),
-            }
-            .into(),
-          );
-        }
-      }
-      if let Some(config_url) = found_configs.into_keys().next() {
-        return Err(
-          WorkspaceDiscoverErrorKind::ConfigNotWorkspaceMember {
-            workspace_url: workspace_config_file.specifier.clone(),
-            config_url,
-          }
-          .into(),
-        );
-      }
-      return Ok(ConfigFileDiscovery::Workspace {
-        root: new_rc(workspace_config_file),
-        members: final_members,
-      });
-    } else {
-      if first_config_file.is_none() {
-        first_config_file = Some(workspace_config_file.specifier.clone());
-      }
-      next_start_dir =
-        specifier_to_file_path(&workspace_config_file.specifier)?
-          .parent()
-          .and_then(|p| p.parent())
-          .map(|p| Cow::Owned(p.to_owned()));
-      found_configs.insert(
-        workspace_config_file.specifier.clone(),
-        workspace_config_file,
-      );
-    }
-  }
-
-  if let Some(first_config_file) = first_config_file {
-    let config = found_configs.remove(&first_config_file).unwrap();
-    Ok(ConfigFileDiscovery::Single(new_rc(config)))
-  } else {
-    Ok(ConfigFileDiscovery::None)
-  }
-}
-
-#[derive(Debug)]
-pub enum PackageJsonDiscovery {
-  None,
-  Single(PackageJsonRc),
-  Workspace {
-    root: PackageJsonRc,
-    members: BTreeMap<UrlRc, PackageJsonRc>,
-  },
-}
-
-pub fn discover_with_npm(
-  start: WorkspaceDiscoverStart,
-  config_file_discovery: &ConfigFileDiscovery,
-  opts: &WorkspaceDiscoverOptions,
-) -> Result<PackageJsonDiscovery, WorkspaceDiscoverError> {
-  let mut found_configs: HashMap<PathBuf, PackageJsonRc> = HashMap::new();
-  let mut first_config_file = None;
-  let maybe_stop_config_file_path = match &config_file_discovery {
-    ConfigFileDiscovery::None => None,
-    ConfigFileDiscovery::Single(config_file) => {
-      Some(specifier_to_file_path(&config_file.specifier).unwrap())
-    }
-    ConfigFileDiscovery::Workspace { root, .. } => {
-      Some(specifier_to_file_path(&root.specifier).unwrap())
-    }
-  };
-  let maybe_stop_dir = maybe_stop_config_file_path
-    .as_ref()
-    .and_then(|p| p.parent())
-    .and_then(|p| p.parent());
-  for ancestor in start.dir_path().ancestors() {
-    if Some(ancestor) == maybe_stop_dir {
-      break;
-    }
-    let pkg_json_path = ancestor.join("package.json");
-    let pkg_json = match PackageJson::load_from_path(
-      &pkg_json_path,
-      opts.fs,
-      opts.pkg_json_cache,
-    ) {
-      Ok(pkg_json) => pkg_json,
-      Err(PackageJsonLoadError::Io { source, .. })
-        if is_skippable_io_error(&source) =>
-      {
-        continue; // keep going
-      }
-      Err(err) => return Err(WorkspaceDiscoverError(Box::new(err.into()))),
-    };
-    log::debug!("package.json file found at '{}'", pkg_json_path.display());
-    if let Some(members) = &pkg_json.workspaces {
-      let mut has_warned = false;
-      let mut final_members = BTreeMap::new();
-      for member in members {
-        if member.contains('*') {
-          if !has_warned {
-            has_warned = true;
-            log::warn!(
-              "Wildcards in npm workspaces are not yet supported. Ignoring."
-            );
-          }
-          continue;
-        }
-
-        let mut find_config = || {
-          let pkg_json_path =
-            normalize_path(ancestor.join(member).join("package.json"));
-          if !pkg_json_path.starts_with(ancestor) {
-            return Err(ResolveWorkspaceMemberError::NonDescendant {
-              workspace_url: Url::from_directory_path(ancestor).unwrap(),
-              member_url: Url::from_directory_path(
-                pkg_json_path.parent().unwrap(),
-              )
-              .unwrap(),
-            });
-          }
-          // try to find the package.json in memory from what we already
-          // found on the file system
-          if let Some(pkg_json) = found_configs.remove(&pkg_json_path) {
-            return Ok(pkg_json);
-          }
-
-          // now search the file system
-          PackageJson::load_from_path(
-            &pkg_json_path,
-            opts.fs,
-            opts.pkg_json_cache,
-          )
-          .map_err(|e| e.into())
-        };
-
-        let pkg_json = match find_config() {
-          Ok(config) => config,
-          Err(err) => {
-            log::warn!("Failed loading package.json, but ignoring. {:#}", err);
-            continue;
-          }
-        };
-        final_members.insert(
-          new_rc(Url::from_file_path(pkg_json.path.parent().unwrap()).unwrap()),
-          pkg_json,
-        );
       }
 
       // just include any remaining found configs as workspace members
       // instead of erroring for now
-      for (path, config) in found_configs {
-        let url = new_rc(Url::from_file_path(path.parent().unwrap()).unwrap());
-        final_members.insert(url, config);
+      let is_root_deno_json_workspace = root_config_folder
+        .deno_json()
+        .map(|d| d.json.workspace.is_some())
+        .unwrap_or(false);
+      for (url, config_folder) in found_config_folders {
+        if is_root_deno_json_workspace {
+          return Err(
+            WorkspaceDiscoverErrorKind::ConfigNotWorkspaceMember {
+              workspace_url: root_config_folder.folder_url(),
+              config_url: config_folder_config_specifier(&config_folder)
+                .into_owned(),
+            }
+            .into(),
+          );
+        } else {
+          // otherwise, be lenient and just add it to the workspace
+          let url = new_rc(url);
+          final_members.insert(url, config_folder);
+        }
       }
 
-      return Ok(PackageJsonDiscovery::Workspace {
-        root: pkg_json,
+      return Ok(ConfigFileDiscovery::Workspace {
+        root: root_config_folder,
         members: final_members,
       });
-    } else {
-      if first_config_file.is_none() {
-        first_config_file = Some(pkg_json.path.clone());
-      }
-      found_configs.insert(pkg_json.path.clone(), pkg_json);
     }
+
+    let config_folder_url = root_config_folder.folder_url();
+    if first_config_folder_url.is_none() {
+      first_config_folder_url = Some(config_folder_url.clone());
+    }
+    found_config_folders.insert(config_folder_url, root_config_folder);
   }
 
-  if let Some(first_config_file) = first_config_file {
-    let config = found_configs.remove(&first_config_file).unwrap();
-    Ok(PackageJsonDiscovery::Single(config))
+  if let Some(first_config_folder_url) = first_config_folder_url {
+    let config = found_config_folders
+      .remove(&first_config_folder_url)
+      .unwrap();
+    Ok(ConfigFileDiscovery::Single(config))
   } else {
-    log::debug!("No package.json file found");
-    Ok(PackageJsonDiscovery::None)
+    Ok(ConfigFileDiscovery::None)
   }
 }

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -324,7 +324,7 @@ fn discover_workspace_config_files_for_single_dir(
           // try to find the config folder in memory from the configs we already
           // found on the file system
           if let Some(config_folder) =
-            found_config_folders.remove(&member_dir_url)
+            found_config_folders.remove(member_dir_url)
           {
             return Ok(config_folder);
           }
@@ -365,7 +365,7 @@ fn discover_workspace_config_files_for_single_dir(
           for raw_member in members {
             let member_dir_url = resolve_member_url(raw_member)?;
             let member_config_folder =
-              find_member_config_folder(&raw_member, &member_dir_url)?;
+              find_member_config_folder(raw_member, &member_dir_url)?;
             add_member(raw_member, member_dir_url, member_config_folder)?;
           }
         }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2903,7 +2903,7 @@ mod test {
     fs: &TestFileSystem,
     start_dir: &Path,
   ) -> Result<WorkspaceRc, WorkspaceDiscoverError> {
-    workspace_at_start_dirs(fs, &vec![start_dir.to_path_buf()])
+    workspace_at_start_dirs(fs, &[start_dir.to_path_buf()])
   }
 
   fn workspace_at_start_dirs(

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2703,7 +2703,6 @@ mod test {
     );
     fs.insert_json(root_dir().join("member/deno.json"), json!({}));
     fs.insert_json(root_dir().join("package/deno.json"), json!({}));
-    // npm package needs to be a member of the deno workspace
     let err = workspace_at_start_dir_err(&fs, &root_dir().join("package"));
     assert_eq!(
       err.to_string(),

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -326,10 +326,6 @@ impl Workspace {
         start_dir,
       },
       ConfigFileDiscovery::Single(config_folder) => {
-        if config_folder.pkg_json().is_none() {
-          // this is used in some cli tests
-          log::debug!("No package.json file found");
-        }
         let root_dir = new_rc(config_folder.folder_url());
         Workspace {
           config_folders: IndexMap::from([(

--- a/src/workspace/resolver.rs
+++ b/src/workspace/resolver.rs
@@ -787,7 +787,7 @@ mod test {
   ) -> WorkspaceRc {
     new_rc(
       Workspace::discover(
-        WorkspaceDiscoverStart::Dir(start_dir),
+        WorkspaceDiscoverStart::Dirs(&[start_dir.to_path_buf()]),
         &WorkspaceDiscoverOptions {
           fs,
           discover_pkg_json: true,


### PR DESCRIPTION
This is better config discovery that isn't as confusing and cause issues like [this](https://twitter.com/DavidSherret/status/1791513568321380378).

Essentially now that we have workspaces, we can use the exact same rules for discovering deno.json files that we do for package.json files:

1. When discovering the configs it looks for both package.json and deno.json at the same time.
2. If we find a deno.json with a workspace we stop. If we find a package.json with a workspace, then we stop.
4. When not in a workspace, we stop on the first deno.json or first package.json
   - If a deno.json is in a root folder, then it needs to reference the package.json as part of the workspace in order to be discovered
5. We allow finding both a deno.json and a package.json in the same folder. We allow both of them to be workspaces, but they must be in the same folder for that to work.
6. We have to special case the node_modules folder to auto-discover outside it. For example, if someone runs something at `/home/david/project/node_modules/package/file.js`, then it should start discovery at `/home/david/project/`. That way we don't cause errors about configs not being in a workspace for stuff in the node_modules folder and so we properly discover the project configs (and not stop at the first found package.json)

This is a breaking change for some projects, but it's easy to work around by adding the config as part of the workspace and it will be better in the long term.