### PR TITLE
fix: better cli file argument handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hermit-abi"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.71.0"
+channel = "1.78.0"
 components = ["rustfmt", "clippy"]

--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -1175,8 +1175,8 @@ impl ConfigFile {
           serde_json::from_value(config)
             .context("Failed to parse \"lint\" configuration")?;
         // top level excludes at the start because they're lower priority
-        exclude_patterns.extend(std::mem::take(&mut serialized.files.exclude));
-        serialized.files.exclude = exclude_patterns;
+        exclude_patterns.extend(std::mem::take(&mut serialized.exclude));
+        serialized.exclude = exclude_patterns;
         serialized
           .into_resolved(&self.specifier)
           .context("Invalid lint config.")

--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -149,11 +149,10 @@ fn choose_files(
 #[serde(default, deny_unknown_fields)]
 struct SerializedLintConfig {
   pub rules: LintRulesConfig,
-  #[serde(flatten)]
-  pub files: SerializedFilesConfig,
+  pub include: Option<Vec<String>>,
+  pub exclude: Vec<String>,
 
-  #[serde(rename = "files")]
-  pub deprecated_files: SerializedFilesConfig,
+  pub files: SerializedFilesConfig,
   pub report: Option<String>,
 }
 
@@ -162,9 +161,12 @@ impl SerializedLintConfig {
     self,
     config_file_specifier: &Url,
   ) -> Result<LintConfig, AnyError> {
+    let (include, exclude) = (self.include, self.exclude);
+    let files = SerializedFilesConfig { include, exclude };
+
     Ok(LintConfig {
       options: LintOptionsConfig { rules: self.rules },
-      files: choose_files(self.files, self.deprecated_files)
+      files: choose_files(files, self.files)
         .into_resolved(config_file_specifier)?,
     })
   }

--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -152,7 +152,8 @@ struct SerializedLintConfig {
   pub include: Option<Vec<String>>,
   pub exclude: Vec<String>,
 
-  pub files: SerializedFilesConfig,
+  #[serde(rename = "files")]
+  pub deprecated_files: SerializedFilesConfig,
   pub report: Option<String>,
 }
 
@@ -166,7 +167,7 @@ impl SerializedLintConfig {
 
     Ok(LintConfig {
       options: LintOptionsConfig { rules: self.rules },
-      files: choose_files(files, self.files)
+      files: choose_files(files, self.deprecated_files)
         .into_resolved(config_file_specifier)?,
     })
   }

--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -1259,7 +1259,8 @@ impl ConfigFile {
   /// If the configuration file contains "extra" modules (like TypeScript
   /// `"types"`) options, return them as imports to be added to a module graph.
   pub fn to_maybe_imports(&self) -> Result<Vec<(Url, Vec<String>)>, AnyError> {
-    let Some(compiler_options_value) = self.json.compiler_options.as_ref() else {
+    let Some(compiler_options_value) = self.json.compiler_options.as_ref()
+    else {
       return Ok(Vec::new());
     };
     let Some(types) = compiler_options_value.get("types") else {
@@ -1279,13 +1280,16 @@ impl ConfigFile {
   pub fn to_maybe_jsx_import_source_config(
     &self,
   ) -> Result<Option<JsxImportSourceConfig>, AnyError> {
-    let Some(compiler_options_value) = self.json.compiler_options.as_ref() else {
+    let Some(compiler_options_value) = self.json.compiler_options.as_ref()
+    else {
       return Ok(None);
     };
     let Some(compiler_options) =
-      serde_json::from_value::<CompilerOptions>(compiler_options_value.clone()).ok() else {
-        return Ok(None);
-      };
+      serde_json::from_value::<CompilerOptions>(compiler_options_value.clone())
+        .ok()
+    else {
+      return Ok(None);
+    };
     let module = match compiler_options.jsx.as_deref() {
       Some("react-jsx") => "jsx-runtime".to_string(),
       Some("react-jsxdev") => "jsx-dev-runtime".to_string(),

--- a/src/glob/collector.rs
+++ b/src/glob/collector.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::path::Path;
 use std::path::PathBuf;
@@ -11,7 +12,6 @@ use crate::glob::FilePatternsMatch;
 use crate::glob::PathKind;
 use crate::glob::PathOrPattern;
 use crate::util::normalize_path;
-use crate::util::CheckedSet;
 
 use super::FilePatterns;
 
@@ -118,7 +118,7 @@ impl<TFilter: Fn(WalkEntry) -> bool> FileCollector<TFilter> {
       None
     };
     let mut target_files = Vec::new();
-    let mut visited_paths: CheckedSet<Path> = CheckedSet::default();
+    let mut visited_paths: HashSet<PathBuf> = HashSet::default();
     let file_patterns_by_base = file_patterns.split_by_base();
     for file_patterns in file_patterns_by_base {
       let specified_path = normalize_path(&file_patterns.base);
@@ -147,14 +147,14 @@ impl<TFilter: Fn(WalkEntry) -> bool> FileCollector<TFilter> {
             let opt_out_ignore = specified_path == path;
             let should_ignore_dir =
               !opt_out_ignore && self.is_ignored_dir(&path);
-            if !should_ignore_dir && visited_paths.insert(&path) {
+            if !should_ignore_dir && visited_paths.insert(path.clone()) {
               pending_dirs.push_back(path);
             }
           } else if (self.file_filter)(WalkEntry {
             path: &path,
             metadata,
             patterns: &file_patterns,
-          }) && visited_paths.insert(&path)
+          }) && visited_paths.insert(path.clone())
           {
             target_files.push(path);
           }

--- a/src/glob/mod.rs
+++ b/src/glob/mod.rs
@@ -387,10 +387,6 @@ impl PathOrPatternSet {
     &self.0
   }
 
-  pub fn inner_mut(&mut self) -> &mut Vec<PathOrPattern> {
-    &mut self.0
-  }
-
   pub fn into_path_or_patterns(self) -> Vec<PathOrPattern> {
     self.0
   }

--- a/src/glob/mod.rs
+++ b/src/glob/mod.rs
@@ -396,6 +396,10 @@ impl PathOrPatternSet {
     &self.0
   }
 
+  pub fn inner_mut(&mut self) -> &mut Vec<PathOrPattern> {
+    &mut self.0
+  }
+
   pub fn into_path_or_patterns(self) -> Vec<PathOrPattern> {
     self.0
   }

--- a/src/glob/mod.rs
+++ b/src/glob/mod.rs
@@ -284,8 +284,17 @@ impl FilePatterns {
     // Sort by the longest base path first. This ensures that we visit opted into
     // nested directories first before visiting the parent directory. The directory
     // traverser will handle not going into directories it's already been in.
-    result
-      .sort_by(|a, b| b.base.as_os_str().len().cmp(&a.base.as_os_str().len()));
+    result.sort_by(|a, b| {
+      // try looking at the parents first so that files in the same
+      // folder are kept in the same order that they're provided
+      let (a, b) =
+        if let (Some(a), Some(b)) = (a.base.parent(), b.base.parent()) {
+          (a, b)
+        } else {
+          (a.base.as_path(), b.base.as_path())
+        };
+      b.as_os_str().len().cmp(&a.as_os_str().len())
+    });
 
     result
   }

--- a/src/glob/mod.rs
+++ b/src/glob/mod.rs
@@ -387,6 +387,10 @@ impl PathOrPatternSet {
     &self.0
   }
 
+  pub fn inner_mut(&mut self) -> &mut Vec<PathOrPattern> {
+    &mut self.0
+  }
+
   pub fn into_path_or_patterns(self) -> Vec<PathOrPattern> {
     self.0
   }
@@ -424,6 +428,10 @@ impl PathOrPatternSet {
       }
     }
     result
+  }
+
+  pub fn push(&mut self, item: PathOrPattern) {
+    self.0.push(item);
   }
 
   pub fn append(&mut self, items: impl Iterator<Item = PathOrPattern>) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,47 +1,10 @@
 // Copyright 2018-2024 the Deno authors. MIT license.
 
-use std::marker::PhantomData;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
 use url::Url;
-
-#[derive(Debug)]
-pub struct CheckedSet<T: std::hash::Hash + ?Sized> {
-  _kind: PhantomData<T>,
-  checked: std::collections::HashSet<u64>,
-}
-
-impl<T: std::hash::Hash + ?Sized> Default for CheckedSet<T> {
-  fn default() -> Self {
-    Self {
-      _kind: Default::default(),
-      checked: Default::default(),
-    }
-  }
-}
-
-impl<T: std::hash::Hash + ?Sized> CheckedSet<T> {
-  pub fn with_capacity(capacity: usize) -> Self {
-    Self {
-      _kind: PhantomData,
-      checked: std::collections::HashSet::with_capacity(capacity),
-    }
-  }
-
-  pub fn insert(&mut self, value: &T) -> bool {
-    self.checked.insert(self.get_hash(value))
-  }
-
-  fn get_hash(&self, value: &T) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::Hasher;
-    let mut hasher = DefaultHasher::new();
-    value.hash(&mut hasher);
-    hasher.finish()
-  }
-}
 
 pub fn is_skippable_io_error(e: &std::io::Error) -> bool {
   use std::io::ErrorKind::*;

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -149,7 +149,7 @@ pub fn discover_workspace_config_files(
   opts: &WorkspaceDiscoverOptions,
 ) -> Result<ConfigFileDiscovery, WorkspaceDiscoverError> {
   match start {
-    WorkspaceDiscoverStart::Dirs(dirs) => match dirs.len() {
+    WorkspaceDiscoverStart::Paths(dirs) => match dirs.len() {
       0 => Ok(ConfigFileDiscovery::None),
       1 => {
         let dir = &dirs[0];

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -3513,6 +3513,41 @@ mod test {
     }
   }
 
+  #[test]
+  fn test_split_cli_args_by_deno_json_folder_no_config() {
+    let mut fs = TestFileSystem::default();
+    fs.insert(root_dir().join("path"), ""); // create the root directory
+    let workspace = workspace_at_start_dir(&fs, &root_dir());
+    // two paths, looped to ensure that the order is maintained on
+    // the output and not sorted
+    let path1 = normalize_path(root_dir().join("./path-longer"));
+    let path2 = normalize_path(root_dir().join("./path"));
+    for (path1, path2) in [(&path1, &path2), (&path2, &path1)] {
+      let split = workspace.split_cli_args_by_deno_json_folder(&FilePatterns {
+        base: root_dir(),
+        include: Some(PathOrPatternSet::new(vec![
+          PathOrPattern::Path(path1.clone()),
+          PathOrPattern::Path(path2.clone()),
+        ])),
+        exclude: Default::default(),
+      });
+      assert_eq!(
+        split,
+        IndexMap::from([(
+          new_rc(Url::from_directory_path(root_dir()).unwrap()),
+          FilePatterns {
+            base: root_dir(),
+            include: Some(PathOrPatternSet::new(vec![
+              PathOrPattern::Path(path1.clone()),
+              PathOrPattern::Path(path2.clone()),
+            ])),
+            exclude: Default::default(),
+          }
+        )])
+      );
+    }
+  }
+
   fn workspace_for_root_and_member(
     root: serde_json::Value,
     member: serde_json::Value,

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -998,7 +998,7 @@ impl Workspace {
                 }
               }
               None => {
-                entry.include = pattern.include.clone();
+                entry.include.clone_from(&pattern.include);
               }
             }
           }
@@ -1267,7 +1267,9 @@ impl WorkspaceMemberContext {
     let Some(deno_json) = self.deno_json.as_ref() else {
       return Ok(LintConfig {
         options: Default::default(),
-        files: FilePatterns::new_with_base(self.dir_url.to_file_path().unwrap()),
+        files: FilePatterns::new_with_base(
+          self.dir_url.to_file_path().unwrap(),
+        ),
       });
     };
     let member_config = deno_json.member.to_lint_config()?;
@@ -1320,7 +1322,9 @@ impl WorkspaceMemberContext {
   fn to_fmt_config_inner(&self) -> Result<FmtConfig, AnyError> {
     let Some(deno_json) = self.deno_json.as_ref() else {
       return Ok(FmtConfig {
-        files: FilePatterns::new_with_base(self.dir_url.to_file_path().unwrap()),
+        files: FilePatterns::new_with_base(
+          self.dir_url.to_file_path().unwrap(),
+        ),
         options: Default::default(),
       });
     };
@@ -1374,7 +1378,9 @@ impl WorkspaceMemberContext {
   fn to_bench_config_inner(&self) -> Result<BenchConfig, AnyError> {
     let Some(deno_json) = self.deno_json.as_ref() else {
       return Ok(BenchConfig {
-        files: FilePatterns::new_with_base(self.dir_url.to_file_path().unwrap()),
+        files: FilePatterns::new_with_base(
+          self.dir_url.to_file_path().unwrap(),
+        ),
       });
     };
     let member_config = deno_json.member.to_bench_config()?;
@@ -1446,7 +1452,9 @@ impl WorkspaceMemberContext {
   fn to_publish_config_inner(&self) -> Result<PublishConfig, AnyError> {
     let Some(deno_json) = self.deno_json.as_ref() else {
       return Ok(PublishConfig {
-        files: FilePatterns::new_with_base(self.dir_url.to_file_path().unwrap()),
+        files: FilePatterns::new_with_base(
+          self.dir_url.to_file_path().unwrap(),
+        ),
       });
     };
     let member_config = deno_json.member.to_publish_config()?;
@@ -1472,8 +1480,10 @@ impl WorkspaceMemberContext {
   fn to_test_config_inner(&self) -> Result<TestConfig, AnyError> {
     let Some(deno_json) = self.deno_json.as_ref() else {
       return Ok(TestConfig {
-        files: FilePatterns::new_with_base(self.dir_url.to_file_path().unwrap()),
-    });
+        files: FilePatterns::new_with_base(
+          self.dir_url.to_file_path().unwrap(),
+        ),
+      });
     };
     let member_config = deno_json.member.to_test_config()?;
     let root_config = match &deno_json.root {
@@ -1577,10 +1587,9 @@ fn combine_option_vecs_with_override<T: Eq + std::hash::Hash + Clone>(
     (Some(root), Some(member)) => {
       let capacity = root.len() + member.len();
       Some(match member {
-        Cow::Owned(m) => remove_duplicates_iterator(
-          root.into_iter().chain(m.into_iter()),
-          capacity,
-        ),
+        Cow::Owned(m) => {
+          remove_duplicates_iterator(root.into_iter().chain(m), capacity)
+        }
         Cow::Borrowed(m) => remove_duplicates_iterator(
           root.into_iter().chain(m.iter().map(|c| (*c).clone())),
           capacity,

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -33,7 +33,6 @@ use crate::package_json::PackageJson;
 use crate::package_json::PackageJsonLoadError;
 use crate::package_json::PackageJsonRc;
 use crate::sync::new_rc;
-use crate::util::CheckedSet;
 use crate::BenchConfig;
 use crate::ConfigFileRc;
 use crate::FmtConfig;
@@ -1631,7 +1630,7 @@ fn combine_option_vecs_with_override<T: Eq + std::hash::Hash + Clone>(
   }
 }
 
-fn combine_option_vecs<T: Eq + std::hash::Hash>(
+fn combine_option_vecs<T: Eq + std::hash::Hash + Clone>(
   root_option: Option<Vec<T>>,
   member_option: Option<Vec<T>>,
 ) -> Option<Vec<T>> {
@@ -1655,14 +1654,14 @@ fn combine_option_vecs<T: Eq + std::hash::Hash>(
   }
 }
 
-fn remove_duplicates_iterator<T: Eq + std::hash::Hash>(
+fn remove_duplicates_iterator<T: Eq + std::hash::Hash + Clone>(
   iterator: impl IntoIterator<Item = T>,
   capacity: usize,
 ) -> Vec<T> {
-  let mut seen = CheckedSet::with_capacity(capacity);
+  let mut seen = HashSet::with_capacity(capacity);
   let mut result = Vec::with_capacity(capacity);
   for item in iterator {
-    if seen.insert(&item) {
+    if seen.insert(item.clone()) {
       result.push(item);
     }
   }

--- a/src/workspace/resolver.rs
+++ b/src/workspace/resolver.rs
@@ -787,7 +787,7 @@ mod test {
   ) -> WorkspaceRc {
     new_rc(
       Workspace::discover(
-        WorkspaceDiscoverStart::Dirs(&[start_dir.to_path_buf()]),
+        WorkspaceDiscoverStart::Paths(&[start_dir.to_path_buf()]),
         &WorkspaceDiscoverOptions {
           fs,
           discover_pkg_json: true,

--- a/src/workspace/resolver.rs
+++ b/src/workspace/resolver.rs
@@ -426,7 +426,10 @@ impl WorkspaceResolver {
       .package_jsons()
       .find(|p| p.name.as_deref() == Some(name));
     let Some(pkg_json) = pkg_json else {
-      return Err(WorkspaceResolvePkgJsonFolderErrorKind::NotFound(name.to_string()).into());
+      return Err(
+        WorkspaceResolvePkgJsonFolderErrorKind::NotFound(name.to_string())
+          .into(),
+      );
     };
     match version_req.inner() {
       RangeSetOrTag::RangeSet(set) => {


### PR DESCRIPTION
Fixes a bug where things would fall apart when arguments were provided.

This now takes the CLI arguments and merges them in with the config in the different workspace members.

CLI PR: https://github.com/denoland/deno/pull/24447

Part of https://github.com/denoland/deno/issues/24422