### PR TITLE
feat(deno_json): support "workspace" as an object

### DIFF
--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -430,6 +430,15 @@ pub enum LockConfig {
   PathBuf(PathBuf),
 }
 
+#[derive(Debug, Error)]
+#[error("Failed to parse \"workspace\" configuration.")]
+pub struct WorkspaceConfigParseError(#[source] serde_json::Error);
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct WorkspaceConfig {
+  pub members: Vec<String>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Task {
@@ -507,7 +516,7 @@ pub struct ConfigFileJson {
 
   pub name: Option<String>,
   pub version: Option<String>,
-  pub workspace: Option<Vec<String>>,
+  pub workspace: Option<Value>,
   #[serde(rename = "workspaces")]
   pub(crate) deprecated_workspaces: Option<Vec<String>>,
   pub exports: Option<Value>,
@@ -1220,6 +1229,27 @@ impl ConfigFile {
       None => Ok(PublishConfig {
         files: self.to_exclude_files_config()?,
       }),
+    }
+  }
+
+  pub fn to_workspace_config(
+    &self,
+  ) -> Result<Option<WorkspaceConfig>, WorkspaceConfigParseError> {
+    match self.json.workspace.clone() {
+      Some(config) => match config {
+        Value::Null => Ok(None),
+        Value::Array(_) => {
+          let members: Vec<String> = serde_json::from_value(config)
+            .map_err(WorkspaceConfigParseError)?;
+          Ok(Some(WorkspaceConfig { members }))
+        }
+        _ => {
+          let config: WorkspaceConfig = serde_json::from_value(config)
+            .map_err(WorkspaceConfigParseError)?;
+          Ok(Some(config))
+        }
+      },
+      None => Ok(None),
     }
   }
 

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -380,8 +380,8 @@ fn discover_workspace_config_files_for_single_dir(
         }
       };
       if let Some(deno_json) = root_config_folder.deno_json() {
-        if let Some(members) = &deno_json.json.workspace {
-          if members.is_empty() {
+        if let Some(workspace_config) = deno_json.to_workspace_config()? {
+          if workspace_config.members.is_empty() {
             return Err(
               WorkspaceDiscoverErrorKind::MembersEmpty(
                 deno_json.specifier.clone(),
@@ -389,7 +389,7 @@ fn discover_workspace_config_files_for_single_dir(
               .into(),
             );
           }
-          for raw_member in members {
+          for raw_member in &workspace_config.members {
             let member_dir_url = resolve_member_url(raw_member)?;
             let member_config_folder =
               find_member_config_folder(raw_member, &member_dir_url)?;

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -49,6 +49,7 @@ use crate::Task;
 use crate::TestConfig;
 use crate::TsConfigForEmit;
 use crate::TsConfigType;
+use crate::WorkspaceConfigParseError;
 use crate::WorkspaceLintConfig;
 
 mod discovery;
@@ -189,6 +190,8 @@ pub enum WorkspaceDiscoverErrorKind {
   ConfigRead(#[from] ConfigFileReadError),
   #[error(transparent)]
   PackageJsonReadError(#[from] PackageJsonLoadError),
+  #[error(transparent)]
+  WorkspaceConfigParse(#[from] WorkspaceConfigParseError),
   #[error("Workspace members cannot be empty.\n  Workspace: {0}")]
   MembersEmpty(Url),
   #[error(transparent)]
@@ -2908,7 +2911,9 @@ mod test {
     fs.insert_json(
       root_dir().join("workspace/deno.json"),
       json!({
-        "workspace": ["./member"]
+        "workspace": {
+          "members": ["./member"]
+        },
       }),
     );
     fs.insert_json(root_dir().join("workspace/member/deno.json"), json!({}));


### PR DESCRIPTION
This makes the naming clear as `"workspace": [...]` is shortform for `"workspace": { "members": [...] }` similar to cargo (https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html#creating-a-workspace) and leaves this open for future properties.

https://github.com/denoland/deno/issues/24456#issuecomment-2212195697