### PR TITLE
refactor: rename `to_maybe_imports()` to `to_compiler_option_types()`

### DIFF
--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -1259,8 +1259,6 @@ impl ConfigFile {
     }
   }
 
-  /// If the configuration file contains "extra" modules (like TypeScript
-  /// `"types"`) options, return them as imports to be added to a module graph.
   pub fn to_compiler_option_types(
     &self,
   ) -> Result<Vec<(Url, Vec<String>)>, AnyError> {

--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -1261,7 +1261,9 @@ impl ConfigFile {
 
   /// If the configuration file contains "extra" modules (like TypeScript
   /// `"types"`) options, return them as imports to be added to a module graph.
-  pub fn to_maybe_imports(&self) -> Result<Vec<(Url, Vec<String>)>, AnyError> {
+  pub fn to_compiler_option_types(
+    &self,
+  ) -> Result<Vec<(Url, Vec<String>)>, AnyError> {
     let Some(compiler_options_value) = self.json.compiler_options.as_ref()
     else {
       return Ok(Vec::new());

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -868,9 +868,13 @@ impl Workspace {
       .unwrap_or(Ok(None))
   }
 
-  pub fn to_maybe_imports(&self) -> Result<Vec<(Url, Vec<String>)>, AnyError> {
+  pub fn to_compiler_option_types(
+    &self,
+  ) -> Result<Vec<(Url, Vec<String>)>, AnyError> {
     self
-      .with_root_config_only(|root_config| root_config.to_maybe_imports())
+      .with_root_config_only(|root_config| {
+        root_config.to_compiler_option_types()
+      })
       .unwrap_or(Ok(Vec::new()))
   }
 
@@ -2067,7 +2071,7 @@ mod test {
       })
     );
     assert_eq!(
-      workspace.to_maybe_imports().unwrap(),
+      workspace.to_compiler_option_types().unwrap(),
       vec![(
         Url::from_file_path(root_dir().join("deno.json")).unwrap(),
         vec!["./types.d.ts".to_string()]


### PR DESCRIPTION
I'm changing this to be conditionally provided to deno_graph in the CLI based on whether the graph kind is including types and so this should be more precise about what it's returning.