### PR TITLE
fix: deny unknown fields for workspace config

### DIFF
--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -440,6 +440,7 @@ pub enum LockConfig {
 pub struct WorkspaceConfigParseError(#[source] serde_json::Error);
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceConfig {
   pub members: Vec<String>,
 }


### PR DESCRIPTION
Forgot to do this earlier.