### PR TITLE
fix: allow empty workspace config

### DIFF
--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -389,14 +389,6 @@ fn discover_workspace_config_files_for_single_dir(
         };
       if let Some(deno_json) = root_config_folder.deno_json() {
         if let Some(workspace_config) = deno_json.to_workspace_config()? {
-          if workspace_config.members.is_empty() {
-            return Err(
-              WorkspaceDiscoverErrorKind::MembersEmpty(
-                deno_json.specifier.clone(),
-              )
-              .into(),
-            );
-          }
           for raw_member in &workspace_config.members {
             let member_dir_url = resolve_member_url(raw_member)?;
             if member_dir_url == root_config_file_directory_url {


### PR DESCRIPTION
This allows stopping auto-discovery in ancestor directories which could contain stuff like npm workspaces.