### PR TITLE
refactor: separate WorkspaceContext and Workspace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(clippy::unused_async)]
 
 #[cfg(feature = "deno_json")]
-mod deno_json;
+pub mod deno_json;
 pub mod fs;
 #[cfg(feature = "deno_json")]
 pub mod glob;
@@ -18,7 +18,5 @@ mod util;
 #[cfg(feature = "workspace")]
 pub mod workspace;
 
-#[cfg(feature = "deno_json")]
-pub use deno_json::*;
 #[cfg(feature = "deno_json")]
 pub use util::SpecifierToFilePathError;

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 use indexmap::IndexSet;
 use url::Url;
 
+use crate::deno_json::ConfigFile;
+use crate::deno_json::ConfigFileRc;
 use crate::glob::is_glob_pattern;
 use crate::glob::FileCollector;
 use crate::glob::FilePatterns;
@@ -21,8 +23,6 @@ use crate::package_json::PackageJsonRc;
 use crate::sync::new_rc;
 use crate::util::is_skippable_io_error;
 use crate::util::specifier_parent;
-use crate::ConfigFile;
-use crate::ConfigFileRc;
 
 use super::ResolveWorkspaceMemberError;
 use super::UrlRc;


### PR DESCRIPTION
After this PR, I'll add a `Workspace` cache similar to the deno_json and package.json, which will help out in the LSP.

Closes https://github.com/denoland/deno_config/issues/93