### PR TITLE
refactor: combine WorkspaceContext and WorkspaceMemberContext to WorkspaceDirectory

### DIFF
--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -40,14 +40,6 @@ pub use ts::IgnoredCompilerOptions;
 pub use ts::JsxImportSourceConfig;
 pub use ts::TsConfig;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub enum ConfigFlag {
-  #[default]
-  Discover,
-  Path(String),
-  Disabled,
-}
-
 #[derive(Clone, Debug, Default, Deserialize, Hash, PartialEq)]
 #[serde(default, deny_unknown_fields)]
 pub struct LintRulesConfig {
@@ -174,11 +166,6 @@ impl SerializedLintConfig {
 }
 
 #[derive(Clone, Debug, Default, Hash, PartialEq)]
-pub struct WorkspaceLintConfig {
-  pub report: Option<String>,
-}
-
-#[derive(Clone, Debug, Default, Hash, PartialEq)]
 pub struct LintOptionsConfig {
   pub rules: LintRulesConfig,
 }
@@ -190,7 +177,7 @@ pub struct LintConfig {
 }
 
 impl LintConfig {
-  pub fn default_with_base(base: PathBuf) -> Self {
+  pub fn new_with_base(base: PathBuf) -> Self {
     // note: don't create Default implementations of these
     // config structs because the base of FilePatterns matters
     Self {
@@ -321,7 +308,7 @@ pub struct FmtConfig {
 }
 
 impl FmtConfig {
-  pub fn default_with_base(base: PathBuf) -> Self {
+  pub fn new_with_base(base: PathBuf) -> Self {
     Self {
       options: Default::default(),
       files: FilePatterns::new_with_base(base),
@@ -388,7 +375,7 @@ pub struct TestConfig {
 }
 
 impl TestConfig {
-  pub fn default_with_base(base: PathBuf) -> Self {
+  pub fn new_with_base(base: PathBuf) -> Self {
     Self {
       files: FilePatterns::new_with_base(base),
     }
@@ -425,7 +412,7 @@ pub struct PublishConfig {
 }
 
 impl PublishConfig {
-  pub fn default_with_base(base: PathBuf) -> Self {
+  pub fn new_with_base(base: PathBuf) -> Self {
     Self {
       files: FilePatterns::new_with_base(base),
     }
@@ -465,7 +452,7 @@ pub struct BenchConfig {
 }
 
 impl BenchConfig {
-  pub fn default_with_base(base: PathBuf) -> Self {
+  pub fn new_with_base(base: PathBuf) -> Self {
     Self {
       files: FilePatterns::new_with_base(base),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(clippy::unused_async)]
 
 #[cfg(feature = "deno_json")]
-mod deno_json;
+pub mod deno_json;
 pub mod fs;
 #[cfg(feature = "deno_json")]
 pub mod glob;
@@ -18,7 +18,5 @@ mod util;
 #[cfg(feature = "workspace")]
 pub mod workspace;
 
-#[cfg(feature = "deno_json")]
-pub use deno_json::*;
 #[cfg(feature = "deno_json")]
 pub use util::SpecifierToFilePathError;

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -491,19 +491,24 @@ fn handle_workspace_with_members(
   // as a member then only resolve the start config
   if !is_root_deno_json_workspace {
     if let Some(first_config_folder) = &first_config_folder_url {
-      if let Some(config_folder) =
-        found_config_folders.remove(first_config_folder)
+      if !root_workspace
+        .config_folders
+        .contains_key(*first_config_folder)
       {
-        let maybe_vendor_dir = resolve_vendor_dir(
-          config_folder.deno_json().map(|d| d.as_ref()),
-          opts.maybe_vendor_override.as_ref(),
-        );
-        let workspace =
-          new_rc(Workspace::new_single(config_folder, maybe_vendor_dir));
-        if let Some(cache) = opts.workspace_cache {
-          cache.set(workspace.root_dir_path(), workspace.clone());
+        if let Some(config_folder) =
+          found_config_folders.remove(first_config_folder)
+        {
+          let maybe_vendor_dir = resolve_vendor_dir(
+            config_folder.deno_json().map(|d| d.as_ref()),
+            opts.maybe_vendor_override.as_ref(),
+          );
+          let workspace =
+            new_rc(Workspace::new_single(config_folder, maybe_vendor_dir));
+          if let Some(cache) = opts.workspace_cache {
+            cache.set(workspace.root_dir_path(), workspace.clone());
+          }
+          return Ok(ConfigFileDiscovery::Workspace { workspace });
         }
-        return Ok(ConfigFileDiscovery::Workspace { workspace });
       }
     }
   }

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 use indexmap::IndexSet;
 use url::Url;
 
+use crate::deno_json::ConfigFile;
+use crate::deno_json::ConfigFileRc;
 use crate::glob::is_glob_pattern;
 use crate::glob::FileCollector;
 use crate::glob::FilePatterns;
@@ -21,8 +23,6 @@ use crate::package_json::PackageJsonRc;
 use crate::sync::new_rc;
 use crate::util::is_skippable_io_error;
 use crate::util::specifier_parent;
-use crate::ConfigFile;
-use crate::ConfigFileRc;
 
 use super::ResolveWorkspaceMemberError;
 use super::UrlRc;

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -4654,6 +4654,84 @@ mod test {
     assert_eq!(deno_json_cache.0.borrow().len(), 0);
   }
 
+  #[test]
+  fn deno_workspace_discovery_workspace_cache() {
+    let mut fs = TestFileSystem::default();
+    fs.insert(
+      root_dir().join("member/package-a/deno.json"),
+      r#"{ "name": "member-a" }"#,
+    );
+    fs.insert(
+      root_dir().join("member/package-b/deno.json"),
+      r#"{ "name": "member-b" }"#,
+    );
+    fs.insert(
+      root_dir().join("deno.json"),
+      r#"{ "workspace": ["member/package-a", "member/package-b"] }"#,
+    );
+    let deno_json_cache = DenoJsonMemCache::default();
+    let pkg_json_cache = PkgJsonMemCache::default();
+    let workspace_cache = WorkspaceMemCache::default();
+    for start_dir in [
+      root_dir(),
+      root_dir().join("member/package-a"),
+      root_dir().join("member/package-b"),
+    ] {
+      let workspace_ctx = WorkspaceContext::discover(
+        WorkspaceDiscoverStart::Paths(&[start_dir]),
+        &WorkspaceDiscoverOptions {
+          fs: &fs,
+          discover_pkg_json: true,
+          deno_json_cache: Some(&deno_json_cache),
+          pkg_json_cache: Some(&pkg_json_cache),
+          workspace_cache: Some(&workspace_cache),
+          ..Default::default()
+        },
+      )
+      .unwrap();
+      assert_eq!(workspace_ctx.workspace.deno_jsons().count(), 3);
+    }
+  }
+
+  #[test]
+  fn npm_workspace_discovery_workspace_cache() {
+    let mut fs = TestFileSystem::default();
+    fs.insert(
+      root_dir().join("member/package-a/package.json"),
+      r#"{ "name": "member-a" }"#,
+    );
+    fs.insert(
+      root_dir().join("member/package-b/package.json"),
+      r#"{ "name": "member-b" }"#,
+    );
+    fs.insert(
+      root_dir().join("package.json"),
+      r#"{ "workspaces": ["member/*"] }"#,
+    );
+    let deno_json_cache = DenoJsonMemCache::default();
+    let pkg_json_cache = PkgJsonMemCache::default();
+    let workspace_cache = WorkspaceMemCache::default();
+    for start_dir in [
+      root_dir(),
+      root_dir().join("member/package-a"),
+      root_dir().join("member/package-b"),
+    ] {
+      let workspace_ctx = WorkspaceContext::discover(
+        WorkspaceDiscoverStart::Paths(&[start_dir]),
+        &WorkspaceDiscoverOptions {
+          fs: &fs,
+          discover_pkg_json: true,
+          deno_json_cache: Some(&deno_json_cache),
+          pkg_json_cache: Some(&pkg_json_cache),
+          workspace_cache: Some(&workspace_cache),
+          ..Default::default()
+        },
+      )
+      .unwrap();
+      assert_eq!(workspace_ctx.workspace.package_jsons().count(), 3);
+    }
+  }
+
   fn workspace_for_root_and_member(
     root: serde_json::Value,
     member: serde_json::Value,


### PR DESCRIPTION
1. Shift more methods down to `Workspace`
2. Combine `WorkspaceContext` and `WorkspaceMemberContext` into `WorkspaceDir`