### PR TITLE
feat: add workspace jsr pkg resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23ce551a58eeefc05a48042a9c76d3409c96a1a6a522a82c4ced26930ece201"
+checksum = "cc1ed90f285a3933ed56f392571ac8b8291a82b9ae294fd03cdd2b054b0196f5"
 dependencies = [
  "monch",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.85"
 url = { version = "2.3.1" }
 import_map = { version = "0.20.0", features = ["ext"], optional = true }
 thiserror = "1.0.61"
-deno_semver = { version = "0.5.7", optional = true }
+deno_semver = { version = "0.5.8", optional = true }
 deno_package_json = { version = "0.1.1", optional = true }
 
 [dev-dependencies]

--- a/src/workspace/resolver.rs
+++ b/src/workspace/resolver.rs
@@ -533,8 +533,7 @@ impl WorkspaceResolver {
     pkg: &'a ResolverWorkspaceJsrPackage,
     pkg_req_ref: JsrPackageReqReference,
   ) -> Result<MappedResolution<'a>, MappedResolutionError> {
-    let export_name =
-      normalize_export_name(pkg_req_ref.sub_path().unwrap_or("."));
+    let export_name = pkg_req_ref.export_name();
     match pkg.exports.get(export_name.as_ref()) {
       Some(sub_path) => match pkg.base.join(sub_path) {
         Ok(specifier) => Ok(MappedResolution::WorkspaceJsrPackage {
@@ -628,25 +627,6 @@ impl WorkspaceResolver {
 
   pub fn pkg_json_dep_resolution(&self) -> PackageJsonDepResolution {
     self.pkg_json_dep_resolution
-  }
-}
-
-fn normalize_export_name(sub_path: &str) -> Cow<str> {
-  if sub_path.is_empty() || matches!(sub_path, "/" | ".") {
-    Cow::Borrowed(".")
-  } else {
-    let sub_path = if sub_path.starts_with('/') {
-      Cow::Owned(format!(".{}", sub_path))
-    } else if !sub_path.starts_with("./") {
-      Cow::Owned(format!("./{}", sub_path))
-    } else {
-      Cow::Borrowed(sub_path)
-    };
-    if let Some(prefix) = sub_path.strip_suffix('/') {
-      Cow::Owned(prefix.to_string())
-    } else {
-      sub_path
-    }
   }
 }
 


### PR DESCRIPTION
Moved from https://github.com/denoland/deno_graph/pull/509

This is in order to support workspace jsr resolution in deno compile as we don't use deno_graph for that code.

This code living here will make more sense once we rename this repo to deno_workspace.