### PR TITLE
feat: allow new strictBuiltinIteratorReturn compiler option

### DIFF
--- a/src/deno_json/ts.rs
+++ b/src/deno_json/ts.rs
@@ -122,6 +122,7 @@ static ALLOWED_COMPILER_OPTIONS: phf::Set<&'static str> = phf::phf_set! {
   "noUnusedParameters",
   "strict",
   "strictBindCallApply",
+  "strictBuiltinIteratorReturn",
   "strictFunctionTypes",
   "strictNullChecks",
   "strictPropertyInitialization",


### PR DESCRIPTION
This will be on by default via "strict"