### PR TITLE
fix: use NodeNext resolution in compiler options

### DIFF
--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -1583,6 +1583,8 @@ pub fn get_ts_config_for_emit(
       "jsx": "react",
       "jsxFactory": "React.createElement",
       "jsxFragmentFactory": "React.Fragment",
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext",
     })),
     TsConfigType::Check { lib } => TsConfig::new(json!({
       "allowJs": true,
@@ -1598,7 +1600,8 @@ pub fn get_ts_config_for_emit(
       "inlineSources": true,
       "isolatedModules": true,
       "lib": lib,
-      "module": "esnext",
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext",
       "moduleDetection": "force",
       "noEmit": true,
       "resolveJsonModule": true,
@@ -1620,6 +1623,8 @@ pub fn get_ts_config_for_emit(
       "jsx": "react",
       "jsxFactory": "React.createElement",
       "jsxFragmentFactory": "React.Fragment",
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext",
       "resolveJsonModule": true,
     })),
   };

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2302,6 +2302,8 @@ mod test {
           "jsx": "react-jsx",
           "jsxFactory": "React.createElement",
           "jsxFragmentFactory": "React.Fragment",
+          "module": "NodeNext",
+          "moduleResolution": "NodeNext",
           "resolveJsonModule": true,
           "jsxImportSource": "npm:react"
         })),


### PR DESCRIPTION
I'm not really a fan of this code existing here in deno_config, but I don't have time to refactor it into the CLI atm.

This allows me to upgrade to TypeScript 5.6.