### PR TITLE
BREAKING: remove support for remote import maps specified in the config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,21 +16,6 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bitflags"
@@ -68,12 +38,6 @@ dependencies = [
  "memchr",
  "serde",
 ]
-
-[[package]]
-name = "cc"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
 
 [[package]]
 name = "cfg-if"
@@ -126,7 +90,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "tokio",
  "url",
 ]
 
@@ -195,12 +158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,12 +181,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "idna"
@@ -322,38 +273,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "monch"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b52c1b33ff98142aecea13138bd399b68aa7ab5d9546c300988c345004001eea"
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "once_cell"
@@ -408,12 +331,6 @@ checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pretty_assertions"
@@ -483,12 +400,6 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
@@ -614,29 +525,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
-dependencies = [
- "backtrace",
- "num_cpus",
- "pin-project-lite",
- "tokio-macros",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,3 @@ deno_package_json = { version = "0.1.1", optional = true }
 [dev-dependencies]
 tempfile = "3.4.0"
 pretty_assertions = "1.4.0"
-tokio = { version = "1.10.1", features = ["macros", "rt-multi-thread"] }

--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -927,7 +927,11 @@ impl ConfigFile {
     // try to resolve as a url
     if let Ok(specifier) = Url::parse(value) {
       if specifier.scheme() != "file" {
-        bail!("Only file: specifiers are supported for security reasons in import maps stored in a deno.json");
+        bail!(concat!(
+          "Only file: specifiers are supported for security reasons in import maps ",
+          "stored in a deno.json. To use a remote import map, use the --import-map ",
+          "flag and \"deno.importMap\" in the language server config"
+        ));
       }
       return Ok(Some(specifier_to_file_path(&specifier)?));
     }
@@ -2643,7 +2647,15 @@ Caused by:
     let err = config_file
       .to_import_map(|_url| unreachable!())
       .unwrap_err();
-    assert_eq!(err.to_string(), "Only file: specifiers are supported for security reasons in import maps stored in a deno.json");
+    assert_eq!(
+      err.to_string(),
+      concat!(
+        "Only file: specifiers are supported for security reasons in ",
+        "import maps stored in a deno.json. To use a remote import map, ",
+        "use the --import-map flag and \"deno.importMap\" in the ",
+        "language server config"
+      )
+    );
   }
 
   fn root_url() -> Url {

--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -20,7 +20,6 @@ use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::future::Future;
 use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -921,27 +920,20 @@ impl ConfigFile {
     }
   }
 
-  pub fn to_import_map_specifier(&self) -> Result<Option<Url>, AnyError> {
+  pub fn to_import_map_path(&self) -> Result<Option<PathBuf>, AnyError> {
     let Some(value) = self.json.import_map.as_ref() else {
       return Ok(None);
     };
     // try to resolve as a url
     if let Ok(specifier) = Url::parse(value) {
-      return Ok(Some(specifier));
+      if specifier.scheme() != "file" {
+        bail!("Only file: specifiers are supported for security reasons in import maps stored in a deno.json");
+      }
+      return Ok(Some(specifier_to_file_path(&specifier)?));
     }
     // now as a relative file path
-    if let Ok(config_file_path) = self.specifier.to_file_path() {
-      // people may specify a file path without a leading `./` so
-      // this handles that
-      let path = config_file_path.parent().unwrap().join(value);
-      Url::from_file_path(normalize_path(&path))
-        .map_err(|()| {
-          anyhow::anyhow!("Failed converting {} to url.", path.display())
-        })
-        .map(Some)
-    } else {
-      Ok(Some(self.specifier.join(value)?))
-    }
+    let config_dir_path = self.dir_path();
+    Ok(Some(normalize_path(config_dir_path.join(value))))
   }
 
   pub fn vendor(&self) -> Option<bool> {
@@ -950,13 +942,11 @@ impl ConfigFile {
 
   /// Resolves the import map potentially resolving the file specified
   /// at the "importMap" entry.
-  pub async fn to_import_map<
-    TReturn: Future<Output = Result<String, AnyError>>,
-  >(
+  pub fn to_import_map(
     &self,
-    fetch_text: impl FnOnce(&Url) -> TReturn,
+    fetch_text: impl FnOnce(&Path) -> Result<String, AnyError>,
   ) -> Result<Option<ImportMapWithDiagnostics>, AnyError> {
-    let maybe_result = self.to_import_map_value(fetch_text).await?;
+    let maybe_result = self.to_import_map_value(fetch_text)?;
     match maybe_result {
       Some((specifier, value)) => {
         let import_map =
@@ -969,11 +959,9 @@ impl ConfigFile {
 
   /// Resolves the import map `serde_json::Value` potentially resolving the
   /// file specified at the "importMap" entry.
-  pub async fn to_import_map_value<
-    TReturn: Future<Output = Result<String, AnyError>>,
-  >(
+  pub fn to_import_map_value(
     &self,
-    fetch_text: impl FnOnce(&Url) -> TReturn,
+    read_file: impl FnOnce(&Path) -> Result<String, AnyError>,
   ) -> Result<Option<(Cow<Url>, serde_json::Value)>, AnyError> {
     // has higher precedence over the path
     if self.json.imports.is_some() || self.json.scopes.is_some() {
@@ -982,12 +970,15 @@ impl ConfigFile {
         self.to_import_map_value_from_imports(),
       )))
     } else {
-      match self.to_import_map_specifier()? {
-        Some(import_map_specifier) => {
-          let text = fetch_text(&import_map_specifier).await?;
+      match self.to_import_map_path()? {
+        Some(import_map_path) => {
+          let text = read_file(&import_map_path)?;
           let value = serde_json::from_str(&text)?;
           // does not expand the imports because this one will use the import map standard
-          Ok(Some((Cow::Owned(import_map_specifier), value)))
+          Ok(Some((
+            Cow::Owned(Url::from_file_path(import_map_path).unwrap()),
+            value,
+          )))
         }
         None => Ok(None),
       }
@@ -2527,8 +2518,8 @@ Caused by:
     );
   }
 
-  #[tokio::test]
-  async fn test_to_import_map_imports_entry() {
+  #[test]
+  fn test_to_import_map_imports_entry() {
     let config_text = r#"{
       "imports": { "@std/test": "jsr:@std/test@0.2.0" },
       // will be ignored because imports and scopes takes precedence
@@ -2542,8 +2533,7 @@ Caused by:
     )
     .unwrap();
     let result = config_file
-      .to_import_map(|_url| async { unreachable!() })
-      .await
+      .to_import_map(|_url| unreachable!())
       .unwrap()
       .unwrap();
 
@@ -2561,8 +2551,8 @@ Caused by:
     );
   }
 
-  #[tokio::test]
-  async fn test_to_import_map_scopes_entry() {
+  #[test]
+  fn test_to_import_map_scopes_entry() {
     let config_text = r#"{
       "scopes": { "https://deno.land/x/test/mod.ts": { "@std/test": "jsr:@std/test@0.2.0" } },
       // will be ignored because imports and scopes takes precedence
@@ -2576,8 +2566,7 @@ Caused by:
     )
     .unwrap();
     let result = config_file
-      .to_import_map(|_url| async { unreachable!() })
-      .await
+      .to_import_map(|_url| unreachable!())
       .unwrap()
       .unwrap();
 
@@ -2600,8 +2589,8 @@ Caused by:
     );
   }
 
-  #[tokio::test]
-  async fn test_to_import_map_import_map_entry() {
+  #[test]
+  fn test_to_import_map_import_map_entry() {
     let config_text = r#"{
       "importMap": "import_map.json",
     }"#;
@@ -2613,16 +2602,16 @@ Caused by:
     )
     .unwrap();
     let result = config_file
-      .to_import_map(|url| {
-        assert_eq!(url, &root_url().join("import_map.json").unwrap());
-        async {
-          Ok(
-            r#"{ "imports": { "@std/test": "jsr:@std/test@0.2.0" } }"#
-              .to_string(),
-          )
-        }
+      .to_import_map(|path| {
+        assert_eq!(
+          path,
+          root_url().to_file_path().unwrap().join("import_map.json")
+        );
+        Ok(
+          r#"{ "imports": { "@std/test": "jsr:@std/test@0.2.0" } }"#
+            .to_string(),
+        )
       })
-      .await
       .unwrap()
       .unwrap();
 
@@ -2639,8 +2628,8 @@ Caused by:
     );
   }
 
-  #[tokio::test]
-  async fn test_to_import_map_import_map_remote() {
+  #[test]
+  fn test_to_import_map_import_map_remote() {
     let config_text = r#"{
       "importMap": "https://deno.land/import_map.json",
     }"#;
@@ -2651,71 +2640,10 @@ Caused by:
       &ConfigParseOptions::default(),
     )
     .unwrap();
-    let result = config_file
-      .to_import_map(|url| {
-        assert_eq!(url.as_str(), "https://deno.land/import_map.json");
-        async {
-          Ok(
-            r#"{ "imports": { "@std/test": "jsr:@std/test@0.2.0" } }"#
-              .to_string(),
-          )
-        }
-      })
-      .await
-      .unwrap()
-      .unwrap();
-
-    assert_eq!(
-      result.import_map.base_url().as_str(),
-      "https://deno.land/import_map.json"
-    );
-    assert_eq!(
-      json!(result.import_map.imports()),
-      // imports should NOT be expanded
-      json!({
-        "@std/test": "jsr:@std/test@0.2.0",
-      })
-    );
-  }
-
-  #[tokio::test]
-  async fn test_to_import_map_import_map_remote_relative() {
-    let config_text = r#"{
-      "importMap": "./import_map.json",
-    }"#;
-    let config_specifier =
-      Url::parse("https://deno.land/import_map.json").unwrap();
-    let config_file = ConfigFile::new(
-      config_text,
-      config_specifier,
-      &ConfigParseOptions::default(),
-    )
-    .unwrap();
-    let result = config_file
-      .to_import_map(|url| {
-        assert_eq!(url.as_str(), "https://deno.land/import_map.json");
-        async {
-          Ok(
-            r#"{ "imports": { "@std/test": "jsr:@std/test@0.2.0" } }"#
-              .to_string(),
-          )
-        }
-      })
-      .await
-      .unwrap()
-      .unwrap();
-
-    assert_eq!(
-      result.import_map.base_url().as_str(),
-      "https://deno.land/import_map.json"
-    );
-    assert_eq!(
-      json!(result.import_map.imports()),
-      // imports should NOT be expanded
-      json!({
-        "@std/test": "jsr:@std/test@0.2.0",
-      })
-    );
+    let err = config_file
+      .to_import_map(|_url| unreachable!())
+      .unwrap_err();
+    assert_eq!(err.to_string(), "Only file: specifiers are supported for security reasons in import maps stored in a deno.json");
   }
 
   fn root_url() -> Url {
@@ -2807,7 +2735,12 @@ Caused by:
   #[test]
   fn resolve_import_map_specifier_parent() {
     let config_text = r#"{ "importMap": "../import_map.json" }"#;
-    let config_specifier = Url::parse("file:///deno/sub/deno.json").unwrap();
+    let file_path = root_url()
+      .join("sub/deno.json")
+      .unwrap()
+      .to_file_path()
+      .unwrap();
+    let config_specifier = Url::from_file_path(&file_path).unwrap();
     let config_file = ConfigFile::new(
       config_text,
       config_specifier,
@@ -2815,12 +2748,13 @@ Caused by:
     )
     .unwrap();
     assert_eq!(
-      config_file
-        .to_import_map_specifier()
+      config_file.to_import_map_path().unwrap().unwrap(),
+      file_path
+        .parent()
         .unwrap()
+        .parent()
         .unwrap()
-        .as_str(),
-      "file:///deno/import_map.json"
+        .join("import_map.json"),
     );
   }
 


### PR DESCRIPTION
This is for security reasons for the time being for Deno 2. Details to follow post Deno 2.0 release.

Remote import maps seem incredibly rare (only 1 usage on GitHub from what I can tell!), so we'll add this back with more permissions if there's enough demand for it: https://github.com/search?type=code&q=%2F%22importMap%22%3A+%22http%2F

In the meantime, use the `--import-map` flag and `"deno.importMap"` config in the LSP.