### PR TITLE
deprecate: remove probing for deno.jsonc

### DIFF
--- a/src/deno_json/mod.rs
+++ b/src/deno_json/mod.rs
@@ -741,7 +741,7 @@ impl ConfigFile {
   pub(crate) fn resolve_config_file_names<'a>(
     additional_config_file_names: &[&'a str],
   ) -> Cow<'a, [&'a str]> {
-    const CONFIG_FILE_NAMES: [&str; 2] = ["deno.json", "deno.jsonc"];
+    const CONFIG_FILE_NAMES: [&str; 1] = ["deno.json"];
     if additional_config_file_names.is_empty() {
       Cow::Borrowed(&CONFIG_FILE_NAMES)
     } else {
@@ -2749,7 +2749,7 @@ Caused by:
 
     let config = ConfigFile::new(
       config_text,
-      root_url().join("deno.jsonc").unwrap(),
+      root_url().join("deno.json").unwrap(),
       &ConfigParseOptions {
         include_task_comments: true,
       },

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -648,7 +648,6 @@ fn resolve_workspace_for_config_folder(
         // it's fine this doesn't use all the possible config file names
         // as this is only used to enhance the error message
         if member_dir_url.as_str().ends_with("/deno.json/")
-          || member_dir_url.as_str().ends_with("/deno.jsonc/")
           || member_dir_url.as_str().ends_with("/package.json/")
         {
           ResolveWorkspaceMemberError::NotFoundMaybeSpecifiedFile {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -3623,70 +3623,68 @@ mod test {
       }
     }
 
-    for file_name in ["deno.json"] {
-      let config_file_path = root_dir().join("member-b").join(file_name);
-      let mut fs = TestFileSystem::default();
-      fs.insert_json(
-        root_dir().join("deno.json"),
-        json!({
-          "workspace": ["./member-a"],
-        }),
-      );
-      fs.insert_json(root_dir().join("member-a/deno.json"), json!({}));
-      fs.insert_json(config_file_path.clone(), json!({}));
-      let err = workspace_at_start_dir_err(&fs, &root_dir().join("member-b"));
-      assert_err(&err, &config_file_path);
+    let file_name = "deno.json";
+    let config_file_path = root_dir().join("member-b").join(file_name);
+    let mut fs = TestFileSystem::default();
+    fs.insert_json(
+      root_dir().join("deno.json"),
+      json!({
+        "workspace": ["./member-a"],
+      }),
+    );
+    fs.insert_json(root_dir().join("member-a/deno.json"), json!({}));
+    fs.insert_json(config_file_path.clone(), json!({}));
+    let err = workspace_at_start_dir_err(&fs, &root_dir().join("member-b"));
+    assert_err(&err, &config_file_path);
 
-      // try for when the config file is specified as well
-      let err = WorkspaceDirectory::discover(
-        WorkspaceDiscoverStart::ConfigFile(&config_file_path),
-        &WorkspaceDiscoverOptions {
-          fs: &fs,
-          discover_pkg_json: true,
-          ..Default::default()
-        },
-      )
-      .unwrap_err();
-      assert_err(&err, &config_file_path);
-    }
+    // try for when the config file is specified as well
+    let err = WorkspaceDirectory::discover(
+      WorkspaceDiscoverStart::ConfigFile(&config_file_path),
+      &WorkspaceDiscoverOptions {
+        fs: &fs,
+        discover_pkg_json: true,
+        ..Default::default()
+      },
+    )
+    .unwrap_err();
+    assert_err(&err, &config_file_path);
   }
 
   #[test]
   fn test_config_not_deno_workspace_member_non_natural_config_file_name() {
-    for file_name in ["other-name.json"] {
-      let mut fs = TestFileSystem::default();
-      fs.insert_json(
-        root_dir().join("deno.json"),
-        json!({
-          "workspace": ["./member-a", "./member-b"],
-        }),
-      );
-      fs.insert_json(root_dir().join("member-a/deno.json"), json!({}));
-      // this is the "natural" config file that would be discovered by
-      // workspace discovery and since the file name specified does not
-      // match it, the workspace is not discovered and an error does not
-      // occur
-      fs.insert_json(root_dir().join("member-b/deno.json"), json!({}));
-      let config_file_path = root_dir().join("member-b").join(file_name);
-      fs.insert_json(config_file_path.clone(), json!({}));
-      let workspace_dir = WorkspaceDirectory::discover(
-        WorkspaceDiscoverStart::ConfigFile(&config_file_path),
-        &WorkspaceDiscoverOptions {
-          fs: &fs,
-          discover_pkg_json: true,
-          ..Default::default()
-        },
-      )
-      .unwrap();
-      assert_eq!(
-        workspace_dir
-          .workspace
-          .deno_jsons()
-          .map(|c| c.specifier.to_file_path().unwrap())
-          .collect::<Vec<_>>(),
-        vec![config_file_path]
-      );
-    }
+    let file_name = "other-name.json";
+    let mut fs = TestFileSystem::default();
+    fs.insert_json(
+      root_dir().join("deno.json"),
+      json!({
+        "workspace": ["./member-a", "./member-b"],
+      }),
+    );
+    fs.insert_json(root_dir().join("member-a/deno.json"), json!({}));
+    // this is the "natural" config file that would be discovered by
+    // workspace discovery and since the file name specified does not
+    // match it, the workspace is not discovered and an error does not
+    // occur
+    fs.insert_json(root_dir().join("member-b/deno.json"), json!({}));
+    let config_file_path = root_dir().join("member-b").join(file_name);
+    fs.insert_json(config_file_path.clone(), json!({}));
+    let workspace_dir = WorkspaceDirectory::discover(
+      WorkspaceDiscoverStart::ConfigFile(&config_file_path),
+      &WorkspaceDiscoverOptions {
+        fs: &fs,
+        discover_pkg_json: true,
+        ..Default::default()
+      },
+    )
+    .unwrap();
+    assert_eq!(
+      workspace_dir
+        .workspace
+        .deno_jsons()
+        .map(|c| c.specifier.to_file_path().unwrap())
+        .collect::<Vec<_>>(),
+      vec![config_file_path]
+    );
   }
 
   #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2081,21 +2081,15 @@ mod test {
     let config_text = json!({
       "workspace": [
         "./a",
-        "./b",
       ],
     });
     let config_text_a = json!({
       "name": "a",
       "version": "0.1.0"
     });
-    let config_text_b = json!({
-      "name": "b",
-      "version": "0.2.0"
-    });
 
     fs.insert_json(root_dir().join("deno.json"), config_text);
     fs.insert_json(root_dir().join("a/deno.json"), config_text_a);
-    fs.insert_json(root_dir().join("b/deno.jsonc"), config_text_b);
 
     let workspace_dir = WorkspaceDirectory::discover(
       WorkspaceDiscoverStart::Paths(&[root_dir()]),
@@ -2105,7 +2099,7 @@ mod test {
       },
     )
     .unwrap();
-    assert_eq!(workspace_dir.workspace.config_folders.len(), 3);
+    assert_eq!(workspace_dir.workspace.config_folders.len(), 2);
   }
 
   #[test]
@@ -3629,7 +3623,7 @@ mod test {
       }
     }
 
-    for file_name in ["deno.json", "deno.jsonc"] {
+    for file_name in ["deno.json"] {
       let config_file_path = root_dir().join("member-b").join(file_name);
       let mut fs = TestFileSystem::default();
       fs.insert_json(
@@ -3659,7 +3653,7 @@ mod test {
 
   #[test]
   fn test_config_not_deno_workspace_member_non_natural_config_file_name() {
-    for file_name in ["other-name.json", "deno.jsonc"] {
+    for file_name in ["other-name.json"] {
       let mut fs = TestFileSystem::default();
       fs.insert_json(
         root_dir().join("deno.json"),


### PR DESCRIPTION
This PR acts as the main block to address issue [remove probing for deno.jsonc](https://github.com/denoland/deno/issues/25793)

**Changes**
- Removed probing for `deno.jsonc`.
- Updated tests in `deno_config` repo in order to absorb the changes.

**Future_work**
If this new approach is to be followed, then `denoland/deno` repo will need updates concerning auto-discovery of deno.jsonc such as spec/integration tests and normal operation of deno across its different subcommands.

**Note**
Deno was tested with the changes of this PR of deno_config, and it's worth to mention:
1) Any operation of deno with deno.jsonc as the default config file will fail with a message conveying the failure of finding config file.
2) In order to force deno to take deno.jsonc as a config file then it must be mentioned explicitly in the command line e.g. `deno run --config deno.jsonc main.ts`.