### PR TITLE
fix: don't panic for invalid package name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "percent-encoding",
  "phf",
  "pretty_assertions",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",
@@ -397,10 +398,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.4.7"
+name = "regex"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -409,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,6 @@ dependencies = [
  "percent-encoding",
  "phf",
  "pretty_assertions",
- "regex",
  "serde",
  "serde_json",
  "tempfile",
@@ -395,18 +394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "1.0.61"
 deno_semver = { version = "0.5.8", optional = true }
 deno_package_json = { version = "0.1.2", optional = true }
 deno_path_util = "0.2.0"
+regex = "1.11.1"
 
 [dev-dependencies]
 tempfile = "3.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ thiserror = "1.0.61"
 deno_semver = { version = "0.5.8", optional = true }
 deno_package_json = { version = "0.1.2", optional = true }
 deno_path_util = "0.2.0"
-regex = "1.11.1"
 
 [dev-dependencies]
 tempfile = "3.4.0"

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -141,8 +141,8 @@ pub enum WorkspaceDiagnosticKind {
     previous: bool,
     suggestion: NodeModulesDirMode,
   },
-  #[error("invalid workspace member \"{name}\".")]
-  InvalidMember { name: String },
+  #[error("Invalid workspace member name \"{name}\". Ensure the name is in the format '@scope/name'.")]
+  InvalidMemberName { name: String },
 }
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -681,7 +681,7 @@ impl Workspace {
         if !is_valid_jsr_pkg_name(name) {
           diagnostics.push(WorkspaceDiagnostic {
             config_url: config.specifier.clone(),
-            kind: WorkspaceDiagnosticKind::InvalidMember { name: name.clone() },
+            kind: WorkspaceDiagnosticKind::InvalidMemberName { name: name.clone() },
           });
         }
       }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1945,7 +1945,7 @@ fn is_valid_jsr_pkg_name(name: &str) -> bool {
   ));
   match jsr {
     Ok(jsr) => jsr.sub_path().is_none(),
-    Err(_) => return false,
+    Err(_) => false,
   }
 }
 

--- a/src/workspace/resolver.rs
+++ b/src/workspace/resolver.rs
@@ -1526,11 +1526,10 @@ mod test {
 
     let diagnostics = workspace.workspace.diagnostics();
     assert_eq!(diagnostics.len(), 1);
-    assert_eq!(
-      diagnostics.first().unwrap().to_string(),
-      r#"invalid workspace member "@deno-test/libs/math". The name should match the pattern "^@[a-z0-9-]+/[a-z0-9-]+$".
-    at file:///home/user/libs/math/deno.json"#
-    );
+    assert!(
+      diagnostics.first().unwrap().to_string().starts_with(
+      r#"invalid workspace member "@deno-test/libs/math". The name should match the pattern "^@[a-z0-9-]+/[a-z0-9-]+$"#
+    ));
   }
 
   fn create_resolver(workspace_dir: &WorkspaceDirectory) -> WorkspaceResolver {

--- a/src/workspace/resolver.rs
+++ b/src/workspace/resolver.rs
@@ -172,8 +172,6 @@ pub enum MappedResolutionError {
   ImportMap(#[from] ImportMapError),
   #[error(transparent)]
   Workspace(#[from] WorkspaceResolveError),
-  #[error("{0}")]
-  Other(String),
 }
 
 impl MappedResolutionError {
@@ -188,7 +186,6 @@ impl MappedResolutionError {
         ImportMapError::Other(_) => false,
       },
       MappedResolutionError::Workspace(_) => false,
-      Self::Other(_) => false,
     }
   }
 }

--- a/src/workspace/resolver.rs
+++ b/src/workspace/resolver.rs
@@ -1530,7 +1530,7 @@ mod test {
       .first()
       .unwrap()
       .to_string()
-      .starts_with(r#"invalid workspace member "@deno-test/libs/math"."#));
+      .starts_with(r#"Invalid workspace member name "@deno-test/libs/math"."#));
   }
 
   fn create_resolver(workspace_dir: &WorkspaceDirectory) -> WorkspaceResolver {

--- a/src/workspace/resolver.rs
+++ b/src/workspace/resolver.rs
@@ -1526,10 +1526,11 @@ mod test {
 
     let diagnostics = workspace.workspace.diagnostics();
     assert_eq!(diagnostics.len(), 1);
-    assert!(
-      diagnostics.first().unwrap().to_string().starts_with(
-      r#"invalid workspace member "@deno-test/libs/math". The name should match the pattern "^@[a-z0-9-]+/[a-z0-9-]+$"#
-    ));
+    assert!(diagnostics
+      .first()
+      .unwrap()
+      .to_string()
+      .starts_with(r#"invalid workspace member "@deno-test/libs/math"."#));
   }
 
   fn create_resolver(workspace_dir: &WorkspaceDirectory) -> WorkspaceResolver {


### PR DESCRIPTION
Removes a panic and adds a new diagnostic for invalid workspace member name:
```
➜ denod task 
Warning invalid workspace member "@tst/a/b". The name should match the pattern "^@[a-z0-9-]+/[a-z0-9-]+$".
    at file:///Users/sr/c/denoland/deno/tst/a/deno.json
Available tasks:
  No tasks found in configuration file
```

Towards https://github.com/denoland/deno/issues/26334