### PR TITLE
fix: don't warn on "compilerOptions.rootDirs"

### DIFF
--- a/src/deno_json/ts.rs
+++ b/src/deno_json/ts.rs
@@ -106,6 +106,7 @@ static ALLOWED_COMPILER_OPTIONS: phf::Set<&'static str> = phf::phf_set! {
   "noUncheckedIndexedAccess",
   "noUnusedLocals",
   "noUnusedParameters",
+  "rootDirs",
   "strict",
   "strictBindCallApply",
   "strictBuiltinIteratorReturn",

--- a/src/workspace/resolver.rs
+++ b/src/workspace/resolver.rs
@@ -446,7 +446,7 @@ pub enum WorkspaceResolverDiagnostic<'a> {
 impl fmt::Display for WorkspaceResolverDiagnostic<'_> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      Self::ImportMap(d) => d.fmt(f),
+      Self::ImportMap(d) => write!(f, "Import map: {d}"),
       Self::CompilerOptionsRootDirs(d) => d.fmt(f),
     }
   }


### PR DESCRIPTION
I missed this somehow.

Ref https://github.com/denoland/deno/pull/27844.