### PR TITLE
fix: resolve default jsxImportSource for jsx automatic

### DIFF
--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1486,6 +1486,15 @@ impl WorkspaceDirectory {
       .map(|r| r.to_raw_jsx_compiler_options())
       .unwrap_or_default();
     let member = config.member.to_raw_jsx_compiler_options();
+    let is_jsx_automatic = matches!(
+      member.jsx.as_deref().or(base.jsx.as_deref()),
+      Some("react-jsx" | "react-jsxdev" | "precompile"),
+    );
+    let create_default_automatic_jsx_import_source =
+      || JsxImportSourceSpecifierConfig {
+        base: config.member.specifier.clone(),
+        specifier: "react".to_string(),
+      };
     let import_source = member
       .jsx_import_source
       .map(|specifier| JsxImportSourceSpecifierConfig {
@@ -1499,6 +1508,9 @@ impl WorkspaceDirectory {
             specifier,
           })
         })
+      })
+      .or_else(|| {
+        is_jsx_automatic.then(create_default_automatic_jsx_import_source)
       });
     let import_source_types = member
       .jsx_import_source_types
@@ -1513,6 +1525,9 @@ impl WorkspaceDirectory {
             specifier,
           })
         })
+      })
+      .or_else(|| {
+        is_jsx_automatic.then(create_default_automatic_jsx_import_source)
       });
     let module = match member.jsx.as_deref().or(base.jsx.as_deref()) {
       Some("react-jsx") => "jsx-runtime".to_string(),

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -5724,6 +5724,32 @@ pub mod test {
   }
 
   #[test]
+  fn test_jsx_import_source_defaults() {
+    let member = workspace_for_root_and_member(
+      json!({
+        "compilerOptions": { "jsx": "react-jsx" }
+      }),
+      json!({}),
+    );
+    let config = member.to_maybe_jsx_import_source_config().unwrap().unwrap();
+    assert_eq!(config.import_source.unwrap().specifier, "react");
+    assert_eq!(config.import_source_types.unwrap().specifier, "react");
+  }
+
+  #[test]
+  fn test_jsx_import_source_types_defaults_import_source() {
+    let member = workspace_for_root_and_member(
+      json!({
+        "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "jsx" }
+      }),
+      json!({}),
+    );
+    let config = member.to_maybe_jsx_import_source_config().unwrap().unwrap();
+    assert_eq!(config.import_source.unwrap().specifier, "jsx");
+    assert_eq!(config.import_source_types.unwrap().specifier, "jsx");
+  }
+
+  #[test]
   fn test_jsx_precompile_skip_setting() {
     let member = workspace_for_root_and_member(
       json!({

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1490,11 +1490,6 @@ impl WorkspaceDirectory {
       member.jsx.as_deref().or(base.jsx.as_deref()),
       Some("react-jsx" | "react-jsxdev" | "precompile"),
     );
-    let create_default_automatic_jsx_import_source =
-      || JsxImportSourceSpecifierConfig {
-        base: config.member.specifier.clone(),
-        specifier: "react".to_string(),
-      };
     let import_source = member
       .jsx_import_source
       .map(|specifier| JsxImportSourceSpecifierConfig {
@@ -1510,7 +1505,10 @@ impl WorkspaceDirectory {
         })
       })
       .or_else(|| {
-        is_jsx_automatic.then(create_default_automatic_jsx_import_source)
+        is_jsx_automatic.then(|| JsxImportSourceSpecifierConfig {
+          base: config.member.specifier.clone(),
+          specifier: "react".to_string(),
+        })
       });
     let import_source_types = member
       .jsx_import_source_types
@@ -1526,9 +1524,7 @@ impl WorkspaceDirectory {
           })
         })
       })
-      .or_else(|| {
-        is_jsx_automatic.then(create_default_automatic_jsx_import_source)
-      });
+      .or_else(|| import_source.clone());
     let module = match member.jsx.as_deref().or(base.jsx.as_deref()) {
       Some("react-jsx") => "jsx-runtime".to_string(),
       Some("react-jsxdev") => "jsx-dev-runtime".to_string(),


### PR DESCRIPTION
This will make deno_graph import this as a dependency.

Part of https://github.com/denoland/deno/issues/28221