### PR TITLE
feat(workspace): read compiler options from tsconfig.json next to package.json

### DIFF
--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -6,6 +6,7 @@ use deno_package_json::PackageJson;
 use deno_package_json::PackageJsonLoadError;
 use deno_package_json::PackageJsonRc;
 use deno_path_util::url_from_directory_path;
+use deno_path_util::url_from_file_path;
 use deno_path_util::url_parent;
 use deno_path_util::url_to_file_path;
 use deno_semver::package::PackageNv;
@@ -1918,7 +1919,7 @@ fn compiler_option_from_ts_config_next_to_pkg_json(
   let mut ts_config_path = pkg_json.path.clone();
   ts_config_path.set_file_name("tsconfig.json");
   if let Ok(text) = std::fs::read_to_string(&ts_config_path) {
-    if let Ok(url) = Url::from_file_path(&ts_config_path) {
+    if let Ok(url) = url_from_file_path(&ts_config_path) {
       if let Ok(config) = ConfigFile::new(&text, url) {
         if let Ok(options) = config.to_compiler_options() {
           return Some(options);

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2025,8 +2025,7 @@ fn compiler_options_from_ts_config_next_to_pkg_json<TSys: FsRead>(
   sys: &TSys,
   pkg_json: &PackageJson,
 ) -> Option<ParsedTsConfigOptions> {
-  let mut path = pkg_json.path.clone();
-  path.set_file_name("tsconfig.json");
+  let path = pkg_json.path.with_file_name("tsconfig.json");
   let warn = |err: &dyn std::fmt::Display| {
     let path = path.display();
     log::warn!("Failed to read tsconfig.json from {}: {}", path, err);

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1445,14 +1445,18 @@ impl WorkspaceDirectory {
       } else if let Some(pkg_json) = &self.pkg_json {
         // if root deno.json doesn't exist, but pkg.json does, try read from
         // tsconfig.json next to pkg.json
-        pkg_json.root.as_ref().map(|p| try_merge_from_ts_config(p));
+        if let Some(pkg_json) = pkg_json.root.as_ref() {
+          try_merge_from_ts_config(pkg_json);
+        }
       }
 
       // then member overwrites
       merge(config.member.to_compiler_options()?)
     } else if let Some(pkg_json) = &self.pkg_json {
       // first, try read from tsconfig.json next to root pkg.json
-      pkg_json.root.as_ref().map(|p| try_merge_from_ts_config(p));
+      if let Some(pkg_json) = pkg_json.root.as_ref() {
+        try_merge_from_ts_config(pkg_json);
+      }
       // then try read from tsconfig.json next to member pkg.json
       try_merge_from_ts_config(&pkg_json.member);
     }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2021,7 +2021,6 @@ impl WorkspaceDirectory {
 
 /// Reads compilerOptions from tsconfig.json file next to the package.json
 /// See https://github.com/denoland/deno/issues/28455#issuecomment-2734956368
-#[allow(clippy::disallowed_methods)]
 fn compiler_options_from_ts_config_next_to_pkg_json<TSys: FsRead>(
   sys: &TSys,
   pkg_json: &PackageJson,

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1917,6 +1917,7 @@ impl WorkspaceDirectory {
 
 /// Reads compilerOptions from tsconfig.json file next to the package.json
 /// See https://github.com/denoland/deno/issues/28455#issuecomment-2734956368
+#[allow(clippy::disallowed_methods)]
 fn compiler_option_from_ts_config_next_to_pkg_json(
   pkg_json: &PackageJson,
 ) -> Option<ParsedTsConfigOptions> {


### PR DESCRIPTION
towards https://github.com/denoland/deno/issues/28455

This PR tries to update `WorkspaceDirectory.to_raw_user_provided_tsconfig` method. The method now reads `compilerOptions` from `tsconfig.json` next to `package.json` if exists.

